### PR TITLE
Add Sebastopol scrapers and auto-update all feeds.txt

### DIFF
--- a/.github/workflows/generate-calendar.yml
+++ b/.github/workflows/generate-calendar.yml
@@ -104,6 +104,26 @@ jobs:
         cd santarosa && python pressdemocrat.py $(date -d "next month" +%Y) $(date -d "next month" +%-m)
       continue-on-error: true
 
+    - name: Scrape SebArts (Sebastopol) - this month
+      run: |
+        cd sebastopol && python sebarts.py --year $(date +%Y) --month $(date +%-m)
+      continue-on-error: true
+
+    - name: Scrape SebArts (Sebastopol) - next month
+      run: |
+        cd sebastopol && python sebarts.py --year $(date -d "next month" +%Y) --month $(date -d "next month" +%-m)
+      continue-on-error: true
+
+    - name: Scrape Occidental Arts (Sebastopol) - this month
+      run: |
+        cd sebastopol && python occidental_arts.py --year $(date +%Y) --month $(date +%-m)
+      continue-on-error: true
+
+    - name: Scrape Occidental Arts (Sebastopol) - next month
+      run: |
+        cd sebastopol && python occidental_arts.py --year $(date -d "next month" +%Y) --month $(date -d "next month" +%-m)
+      continue-on-error: true
+
     # ==========================================
     # Update feeds.txt to point to fresh ICS files
     # ==========================================
@@ -141,6 +161,116 @@ jobs:
         # Remove leading whitespace
         sed -i 's/^[[:space:]]*//' santarosa/feeds.txt
 
+    - name: Update Sebastopol feeds.txt with current month files
+      run: |
+        YEAR=$(date +%Y)
+        MONTH=$(date +%m)
+        NEXT_YEAR=$(date -d "next month" +%Y)
+        NEXT_MONTH=$(date -d "next month" +%m)
+        
+        cat > sebastopol/feeds.txt << EOF
+        # Live calendar feed
+        https://seb.org/?post_type=tribe_events&ical=1&eventDisplay=list
+        
+        # Freshly scraped data (this month)
+        https://raw.githubusercontent.com/judell/community-calendar/main/sebastopol/sebarts_${YEAR}_${MONTH}.ics
+        https://raw.githubusercontent.com/judell/community-calendar/main/sebastopol/occidental_arts_${YEAR}_${MONTH}.ics
+        
+        # Freshly scraped data (next month)
+        https://raw.githubusercontent.com/judell/community-calendar/main/sebastopol/sebarts_${NEXT_YEAR}_${NEXT_MONTH}.ics
+        https://raw.githubusercontent.com/judell/community-calendar/main/sebastopol/occidental_arts_${NEXT_YEAR}_${NEXT_MONTH}.ics
+        EOF
+        sed -i 's/^[[:space:]]*//' sebastopol/feeds.txt
+
+    - name: Update Bloomington feeds.txt with current month files
+      run: |
+        YEAR=$(date +%Y)
+        MONTH=$(date +%m)
+        NEXT_YEAR=$(date -d "next month" +%Y)
+        NEXT_MONTH=$(date -d "next month" +%m)
+        
+        cat > bloomington/feeds.txt << EOF
+        # Freshly scraped data (this month)
+        https://raw.githubusercontent.com/judell/community-calendar/main/bloomington/library_intercept_${YEAR}_${MONTH}.ics
+        https://raw.githubusercontent.com/judell/community-calendar/main/bloomington/eventbrite_${YEAR}_${MONTH}.ics
+        
+        # Freshly scraped data (next month)
+        https://raw.githubusercontent.com/judell/community-calendar/main/bloomington/library_intercept_${NEXT_YEAR}_${NEXT_MONTH}.ics
+        https://raw.githubusercontent.com/judell/community-calendar/main/bloomington/eventbrite_${NEXT_YEAR}_${NEXT_MONTH}.ics
+        
+        # Static feeds
+        https://raw.githubusercontent.com/judell/community-calendar/main/bloomington/bluebird.ics
+        https://bgcbloomington.org/events/list/?ical=1
+        https://calendar.google.com/calendar/ical/369d27c7a9322083baac00a06ca3b0479be0774c6f40c0ab7c86c0659426ef0b%40group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/4dj0guhji982ca5k90ljeliul0%40group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/8d96590ccc4204e8cff7f21fcd9b91bf41b37240881d482a36ea2f4b5bf4a3db%40group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/96tdb02ghjpvqhuos76gac3s7dfh049h%40import.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/b4j4j61ab9c7j3uh1v5ddtfpb25ibfod%40import.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_1b95au4d2ueudldosb024fimp0@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_1oscb1ute6r06q3e5pbgaq3toc@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_2cffk8544baujn0nvt1jke3lns@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_47v9si34k4k4b7ls795ae8bifc@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_5tslrk3kqr4n30m7thpkj70d9k@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_61098baejufv5khvd2rcvekdtk@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_616d8rtu6dqpm88r23f7u8vq10@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_6h6qp7mqju25tsc94udql1dgvc@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_6varnjkfs42dc7ess9aalvvqd8@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_80r816ic69gsssnnt920oemupk@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_833250fduqij1e1j3ht2afvu78@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_9cj462rjc0kigi2h1vjhmmbb3s@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_a33nstcgh5p6jedp3tp1744drk@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_avvoeg5e6830gs4dl4pfuvi3rk@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_c8h30sa04dfe2rgb8iehlrl5uk@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_e6448fd8fi0f52j9bkbre7g430@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_e6juf1jqv1f9jpuv8rit7jorh0@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_f1f8r5obe443tuqurgnofq6geo@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_fgs5r6durioo4qenslecptkov0@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_foeklt0pri1pnq6j5s5eaqtjkk@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_fqm6n7gvf7i872vh4k2bl2qgec@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_g5gnd4ua9d9243ekl6v7tnapoc@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_gc66ngj5ihsrg5da3t2ivrrjl4@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_gifsbt66d0cra0iuha44ih41q4@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_hvg1gmhhfvto0eotut0474tkec@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_ie7haqq1s9bc5ns0uni3k2uf90@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_is80iamoignhkrv607rcvfqmkc@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_j45rtttdqksanm5paj4u6jbbgo@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_knn8pjjd96nosmv22m1dk73a0k@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_l9887mc9q77o7hn1toh6ggkktc@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_mda9anqvkuu6ohqdv745thfub4@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_moqvjq2a3pgd01hdorhpjc1i74@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_mpgjiebjgu0hn0vmmjg1u3pvg0@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_ndl6omraubla6pucoqksbbm1mg@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_o0tjd2ea75995hcholm1kvgs2o@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_oefraaiuk1avt9iqrrira49d6k@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_q9vfi99npbo99h15h19eggr6do@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_qk38oap8v1hpvljtf6nrtvlohg@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_s38rkl9v1lq62jutmd1d60ei1k@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_tfp4djjctjcl3cfa7e3osqr330@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_tk5to6almu9sm471e9cfc20h10@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_tqr3t57n8oqf0ebee05ssbicsg@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_upft0l9q6h6gh9jo1ce25tnk5k@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/bloomington.in.gov_v8fd687sbp4e6vj3u1ihtcarn8@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/c_66747b176289bfbacc2f3805df0fa39ffb490eba8789f55c2c3f8aa02a7f0e20%40group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/c_a69f884433e71fa9dd64f9171dfd23927e26abfe5efa234fdeb45972ba05d625%40group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/c_siu0d8ohqr5j5p936tig34emts@group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/kovia38vljudopq05vqf9aori2q202rm%40import.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/mhcfoodpantry.org_7001o80jf1si95gqj1h88p5558%40group.calendar.google.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/mocofairgrounds%40gmail.com/public/basic.ics
+        https://calendar.google.com/calendar/ical/qq72qficfv7tslhdmm3s01d62jglpc9f%40import.calendar.google.com/public/basic.ics
+        https://events.iu.edu/live/ical/events/category_id/12/group_id/105
+        https://events.iu.edu/live/ical/events/category_id/12/group_id/11
+        https://events.iu.edu/live/ical/events/category_id/12/group_id/25
+        https://events.iu.edu/live/ical/events/category_id/12/group_id/56
+        https://events.iu.edu/live/ical/events/category_id/12/group_id/64
+        https://events.iu.edu/live/ical/events/group_id/129
+        https://events.iu.edu/live/ical/v2/events/category_id/12/group_id/382
+        https://mcpl.evanced.info/signupadmin/eventsxml.aspx?dm=ical&eventid=85020
+        https://tockify.com/api/feeds/ics/bloomington.arts.calendar
+        https://www.bloomingtoncommunityband.org/events/month/?ical=1
+        https://www.vocesnovae.org/concerts/2023/11/12/six-degrees-of-separation?format=ical
+        EOF
+        sed -i 's/^[[:space:]]*//' bloomington/feeds.txt
+
     # ==========================================
     # Generate calendars
     # ==========================================
@@ -164,6 +294,10 @@ jobs:
     - name: Sebastopol, this month
       run: |
         python cal.py --generate --location sebastopol --year $(date +%Y) --month $(date +%m) --timezone "America/Los_Angeles"
+
+    - name: Sebastopol, next month
+      run: |
+        python cal.py --generate --location sebastopol --year $(date -d "next month" +%Y) --month $(date -d "next month" +%m) --timezone "America/Los_Angeles"
       
     - name: Commit and push if changes
       env:


### PR DESCRIPTION
## Changes

### Sebastopol scrapers
- Add `sebarts.py` scraper (this month + next month)
- Add `occidental_arts.py` scraper (this month + next month)

### Auto-update feeds.txt for all locations
- **sebastopol/feeds.txt**: Now auto-generated with current month ICS files
- **bloomington/feeds.txt**: Now auto-generated with current month ICS files (was pointing to stale 2024_09 files)

### Calendar generation
- Add Sebastopol next month generation (was missing)

## Summary
All three locations (Santa Rosa, Sebastopol, Bloomington) now have:
1. Scrapers running for current + next month
2. feeds.txt auto-updated to point to fresh ICS files