### PR TITLE
Fix Puppeteer sandbox issue on GitHub Actions

### DIFF
--- a/eventbrite.js
+++ b/eventbrite.js
@@ -36,7 +36,7 @@ if (!LOCATION_CONFIGS[location] || isNaN(targetYear) || isNaN(targetMonth) || ta
 const locationConfig = LOCATION_CONFIGS[location];
 
 async function scrapeEvents(url, targetYear, targetMonth) {
-    const browser = await puppeteer.launch({ headless: true });
+    const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     const page = await browser.newPage();
     page.setDefaultNavigationTimeout(60000);
 


### PR DESCRIPTION
Add `--no-sandbox` and `--disable-setuid-sandbox` args to `puppeteer.launch()` to work around Ubuntu 23.10+ AppArmor restrictions on unprivileged user namespaces.