### PR TITLE
Add Luther Burbank Center and Schulz Museum ICS feeds

### DIFF
--- a/santarosa/feeds.txt
+++ b/santarosa/feeds.txt
@@ -19,6 +19,10 @@ https://raw.githubusercontent.com/judell/community-calendar/main/santarosa/event
 https://raw.githubusercontent.com/judell/community-calendar/main/santarosa/bohemian_2026_03.ics
 https://raw.githubusercontent.com/judell/community-calendar/main/santarosa/pressdemocrat_2026_03.ics
 
+# Live venue calendars
+https://lutherburbankcenter.org/events/?ical=1
+https://schulzmuseum.org/events/?ical=1
+
 # Santa Rosa City calendars
 https://raw.githubusercontent.com/judell/community-calendar/main/santarosa/SRCity_Main_Calendar.ics
 https://raw.githubusercontent.com/judell/community-calendar/main/santarosa/SRCity_City_Offices_Closed.ics


### PR DESCRIPTION
## New Live ICS Feeds for Santa Rosa

Adds two major venue calendars that expose native ICS feeds:

### Luther Burbank Center for the Arts
- URL: `https://lutherburbankcenter.org/events/?ical=1`
- 58 events (concerts, speakers, theater)
- Major regional performing arts venue

### Charles M. Schulz Museum
- URL: `https://schulzmuseum.org/events/?ical=1`
- 60 events (workshops, exhibitions, family activities)
- Popular local museum

Both use The Events Calendar WordPress plugin which provides reliable ICS export.