### PR TITLE
Add scrapers for 4 new event sources

### DIFF
--- a/cotati/feeds.txt
+++ b/cotati/feeds.txt
@@ -1,0 +1,4 @@
+# Redwood Cafe Cotati - Live music
+cotati/redwood_cafe_2026_02.ics
+cotati/redwood_cafe_2026_03.ics
+cotati/redwood_cafe_2026_04.ics

--- a/cotati/index.html
+++ b/cotati/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cotati Community Calendar</title>
+  <script>
+    // Redirect to current month's list view
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    window.location.href = `${year}-${month}-l.html`;
+  </script>
+  <noscript>
+    <meta http-equiv="refresh" content="0; url=2026-02-l.html">
+  </noscript>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f8f9fa;
+    }
+    a {
+      color: #1e40af;
+      font-size: 1.2rem;
+    }
+  </style>
+</head>
+<body>
+  <p>Redirecting to <a href="2026-02-l.html">Cotati Community Calendar</a>...</p>
+</body>
+</html>

--- a/cotati/redwood_cafe_2026_02.ics
+++ b/cotati/redwood_cafe_2026_02.ics
@@ -1,0 +1,123 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Redwood Cafe Cotati//redwoodcafecotati.com//
+X-WR-CALNAME:Redwood Cafe Cotati - 2026/02
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:Cedar Mountain String Band
+DTSTART:20260205T180000
+DTEND:20260205T210000
+UID:f6e44c9743887e58d6d02c13dc327620@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Blue 7 Jazz Band
+DTSTART:20260206T180000
+DTEND:20260206T210000
+UID:743fe013f85c0779511cf2b7ff04b110@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The Familiar Strangers
+DTSTART:20260207T180000
+DTEND:20260207T210000
+UID:521df9bf6dc6e9f65ed9fbd84d857057@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Brotherly Love Jazz
+DTSTART:20260212T180000
+DTEND:20260212T210000
+UID:5cb88886b691923446cc44a494fd442f@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:3 Acre Holler
+DTSTART:20260213T180000
+DTEND:20260213T210000
+UID:5e12eedc74d2b2221d028f0f4319586e@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:ThornRose Band
+DTSTART:20260214T180000
+DTEND:20260214T210000
+UID:ec50c4e18ca22475f75c318d996f6b0a@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Dixieland Jazz  & Trivia Night @ 7PM
+DTSTART:20260217T173000
+DTEND:20260217T203000
+UID:c74c99f2b135271b6a81d905c234fa87@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Equinox
+DTSTART:20260219T180000
+DTEND:20260219T210000
+UID:7b662c7bdf3210b25cd77638c2647d0b@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:========
+DTSTART:20260220T180000
+DTEND:20260220T210000
+UID:aac15583d102818cb143f18fb1bb0fed@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Thugz Trio
+DTSTART:20260221T180000
+DTEND:20260221T210000
+UID:c30927f806d1fc50e5b9597edc8462d5@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Bitter Blues Band
+DTSTART:20260226T180000
+DTEND:20260226T210000
+UID:40646d04284a249b6c6657bc027074a2@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Zig Zag Jazz Band
+DTSTART:20260227T180000
+DTEND:20260227T210000
+UID:140b2ee83bbe4a56ef220d37aae5edd0@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Real Deal Friends
+DTSTART:20260228T180000
+DTEND:20260228T210000
+UID:a374e3ff67797dcddf66915e725a7dc3@redwoodcafecotati.com
+DESCRIPTION:Live music at Redwood Cafe Cotati.
+LOCATION:Redwood Cafe\, 8240 Old Redwood Hwy\, Cotati\, CA 94931
+URL:https://redwoodcafecotati.com/events/
+END:VEVENT
+END:VCALENDAR

--- a/cotati/redwood_cafe_2026_03.ics
+++ b/cotati/redwood_cafe_2026_03.ics
@@ -1,0 +1,6 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Redwood Cafe Cotati//redwoodcafecotati.com//
+X-WR-CALNAME:Redwood Cafe Cotati - 2026/03
+X-WR-TIMEZONE:America/Los_Angeles
+END:VCALENDAR

--- a/cotati/redwood_cafe_2026_04.ics
+++ b/cotati/redwood_cafe_2026_04.ics
@@ -1,0 +1,6 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Redwood Cafe Cotati//redwoodcafecotati.com//
+X-WR-CALNAME:Redwood Cafe Cotati - 2026/04
+X-WR-TIMEZONE:America/Los_Angeles
+END:VCALENDAR

--- a/santarosa/cal_theatre_2026_02.ics
+++ b/santarosa/cal_theatre_2026_02.ics
@@ -1,0 +1,186 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//California Theatre Santa Rosa//caltheatre.com//
+X-WR-CALNAME:Cal Theatre - 2026/02
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:School of Rock
+DTSTART:20260201T110000
+DTEND:20260201T140000
+UID:4219115d9aaa56faf93809dec2fd87f4@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Monday Pro Jam with Special Guest Tony Lindsay
+DTSTART:20260202T180000
+DTEND:20260202T210000
+UID:83d3adba8ae46bc0fcfef5c0718c11a2@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The Hots
+DTSTART:20260206T193000
+DTEND:20260206T223000
+UID:2ed27b42452fbeec01a661e7051fb94e@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Whole Lotta Love - Bay Area
+DTSTART:20260207T203000
+DTEND:20260207T233000
+UID:b347cc228b28e2b811016390e9e9858c@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:All-Star Improv Showdown
+DTSTART:20260208T193000
+DTEND:20260208T223000
+UID:a10de9e31f2393e087a156cadff1a67f@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Monday Pro Jam -  Randy McDonald
+DTSTART:20260209T180000
+DTEND:20260209T210000
+UID:da02ad3ff244a74814293737b9c193d3@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Forbidden Kiss LIVE - Mardi Gras
+DTSTART:20260213T193000
+DTEND:20260213T223000
+UID:80d9c8031e3eeccb6ca8df035173d43f@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Grateful Heart Band - with Jami Jameson Band
+DTSTART:20260214T193000
+DTEND:20260214T223000
+UID:ebc4c3f87fd33d7a6d31e67dda15e694@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Pro Jam - with special guest Johnny Vernazza
+DTSTART:20260216T180000
+DTEND:20260216T210000
+UID:4f1bc4bc178136704373a739630296ce@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present - PREVIEW
+DTSTART:20260219T193000
+DTEND:20260219T223000
+UID:2769edb2017c504e1cfcea6ed41da65e@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260220T193000
+DTEND:20260220T223000
+UID:9189262cf8d3cc30f6b51b36316ff315@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260221T130000
+DTEND:20260221T160000
+UID:f3de0089d99441a6ea76f6eecda4e19b@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Americana Afternoon - Familiar Strangers
+DTSTART:20260222T130000
+DTEND:20260222T160000
+UID:8bfe9fd8966e00f98d0a05f2a41d52fc@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Pro Jam: Local Heroes Night!
+DTSTART:20260223T180000
+DTEND:20260223T210000
+UID:2faf707acd06ba5d361d4fc65513df40@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260225T193000
+DTEND:20260225T223000
+UID:ca9e33122335d5c368a7733db04f4cb6@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260226T193000
+DTEND:20260226T223000
+UID:3d47a268ee8de0043f6e67c7c757319d@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260227T193000
+DTEND:20260227T223000
+UID:baf665eaa41a45e46803a3b5e5bd8c3d@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260228T130000
+DTEND:20260228T160000
+UID:b0680b6d39f9cec69b1b493ffca98f6e@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+END:VCALENDAR

--- a/santarosa/cal_theatre_2026_03.ics
+++ b/santarosa/cal_theatre_2026_03.ics
@@ -1,0 +1,186 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//California Theatre Santa Rosa//caltheatre.com//
+X-WR-CALNAME:Cal Theatre - 2026/03
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:School of Rock
+DTSTART:20260301T110000
+DTEND:20260301T140000
+UID:5df513977297f0ddf1481d60658fcb7b@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Monday Pro Jam with Special Guest Tony Lindsay
+DTSTART:20260302T180000
+DTEND:20260302T210000
+UID:1e206176f77bd197de4d221998edfa5e@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The Hots
+DTSTART:20260306T193000
+DTEND:20260306T223000
+UID:aa7821d33d333ec52c7a432a87c09f07@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Whole Lotta Love - Bay Area
+DTSTART:20260307T203000
+DTEND:20260307T233000
+UID:7c2252a2cd30ccc0c6909a04b37e9977@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:All-Star Improv Showdown
+DTSTART:20260308T193000
+DTEND:20260308T223000
+UID:fd4701fc96e18491c64c3b8eff944f47@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Monday Pro Jam -  Randy McDonald
+DTSTART:20260309T180000
+DTEND:20260309T210000
+UID:6daf05d8e93ba3795790bae80f5f7185@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Forbidden Kiss LIVE - Mardi Gras
+DTSTART:20260313T193000
+DTEND:20260313T223000
+UID:e967ef9e6bde4fcd21a6ad1726e96b89@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Grateful Heart Band - with Jami Jameson Band
+DTSTART:20260314T193000
+DTEND:20260314T223000
+UID:a543ea79eb8793de6a56555f5e6ae27b@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Pro Jam - with special guest Johnny Vernazza
+DTSTART:20260316T180000
+DTEND:20260316T210000
+UID:df846f3d24ed818b8fe2ba8cddb288bb@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present - PREVIEW
+DTSTART:20260319T193000
+DTEND:20260319T223000
+UID:16dcee2dda39cfeef36a7134fb4e629a@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260320T193000
+DTEND:20260320T223000
+UID:a477b3c46be095cb4f7514befe69dda8@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260321T130000
+DTEND:20260321T160000
+UID:727ab62c31e15d7a7341a6c6ef2d7530@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Americana Afternoon - Familiar Strangers
+DTSTART:20260322T130000
+DTEND:20260322T160000
+UID:da027b28d9a8b9f8e6f031ebe79ff27b@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Pro Jam: Local Heroes Night!
+DTSTART:20260323T180000
+DTEND:20260323T210000
+UID:fa905c49cde2b3f768e64490f77c5abd@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260325T193000
+DTEND:20260325T223000
+UID:4616115dc5d95bca50a508c21260e213@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260326T193000
+DTEND:20260326T223000
+UID:746b83f3ac08d9d9e5adff3346e4769a@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260327T193000
+DTEND:20260327T223000
+UID:204ff932d0b4d94371f9ef59820f46a2@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260328T130000
+DTEND:20260328T160000
+UID:2e7e6c36ec1b15b9a782acc5a98769e5@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+END:VCALENDAR

--- a/santarosa/cal_theatre_2026_04.ics
+++ b/santarosa/cal_theatre_2026_04.ics
@@ -1,0 +1,186 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//California Theatre Santa Rosa//caltheatre.com//
+X-WR-CALNAME:Cal Theatre - 2026/04
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:School of Rock
+DTSTART:20260401T110000
+DTEND:20260401T140000
+UID:56997b7ff4e109a642c8f755dbcaea29@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Monday Pro Jam with Special Guest Tony Lindsay
+DTSTART:20260402T180000
+DTEND:20260402T210000
+UID:631baefb841a3dccd09c08854d96cb97@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:The Hots
+DTSTART:20260406T193000
+DTEND:20260406T223000
+UID:b0a4806fc1a6d9bd546795355a54f5bb@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Whole Lotta Love - Bay Area
+DTSTART:20260407T203000
+DTEND:20260407T233000
+UID:882ff6ec3edc712f9b756953b56324ed@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:All-Star Improv Showdown
+DTSTART:20260408T193000
+DTEND:20260408T223000
+UID:be766e441ef056f088749dfb0eb58684@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Monday Pro Jam -  Randy McDonald
+DTSTART:20260409T180000
+DTEND:20260409T210000
+UID:5463511f668c2967a5bc993576a13882@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Forbidden Kiss LIVE - Mardi Gras
+DTSTART:20260413T193000
+DTEND:20260413T223000
+UID:9d6773cee43347c95788aeb4b794572e@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Grateful Heart Band - with Jami Jameson Band
+DTSTART:20260414T193000
+DTEND:20260414T223000
+UID:ca8957b3616bbc383dc9f8936f83c1ba@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Pro Jam - with special guest Johnny Vernazza
+DTSTART:20260416T180000
+DTEND:20260416T210000
+UID:62474e1114f25c8d67ee3691f330e2d2@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present - PREVIEW
+DTSTART:20260419T193000
+DTEND:20260419T223000
+UID:9b9aaecfed2b6e858a65843b815412dd@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260420T193000
+DTEND:20260420T223000
+UID:9b9565a53b9437ab65ccc264767a0441@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260421T130000
+DTEND:20260421T160000
+UID:e5b21f6ab4fc3bac778ff9d0959fc43d@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Americana Afternoon - Familiar Strangers
+DTSTART:20260422T130000
+DTEND:20260422T160000
+UID:7916e335bf8108a50a00677aa5d5ce3c@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Pro Jam: Local Heroes Night!
+DTSTART:20260423T180000
+DTEND:20260423T210000
+UID:e5e4909045123c091a4acbe4946abc01@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260425T193000
+DTEND:20260425T223000
+UID:ddb35a594d1d67f84340ce38dfd86764@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260426T193000
+DTEND:20260426T223000
+UID:b8300ce448339fc4561d3e7187e10494@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260427T193000
+DTEND:20260427T223000
+UID:68f2d3db0f8d02b85f3de0183b14adff@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:We Are Proud to Present
+DTSTART:20260428T130000
+DTEND:20260428T160000
+UID:d2dba919f3aef22f59293177dc46d6b9@caltheatre.com
+DESCRIPTION:Event at California Theatre. See https://www.caltheatre.com/ca
+ lendar for details.
+LOCATION:California Theatre\, 528 7th St\, Santa Rosa\, CA 95401
+URL:https://www.caltheatre.com/calendar
+END:VEVENT
+END:VCALENDAR

--- a/santarosa/copperfields_2026_02.ics
+++ b/santarosa/copperfields_2026_02.ics
@@ -1,0 +1,206 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Copperfields Books//copperfieldsbooks.com//
+X-WR-CALNAME:Copperfield's Books - 2026/02
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:SARA PENNYPACKER & STACEY LEE
+DTSTART:20260203T180000
+DTEND:20260203T200000
+UID:d18f30afeb241b8828cd279935291c0b@copperfieldsbooks.com
+DESCRIPTION:PetalumaKids Event\, Petaluma\, Kids Event. PETALUMA --\nCeleb
+ rate the release of The Lions' Run in Petaluma with New York Times bestse
+ lling author Sara Pennypacker!\nSara will be joined in conversation by Sta
+ cey Lee\, bestselling a...\n\nMore info: https://copperfieldsbooks.com/eve
+ nt/2026-02-03/sara-pennypacker-stacey-lee
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-03/sara-pennypacker-stacey
+ -lee
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:MAC BARNETT & CARSON ELLIS
+DTSTART:20260205T180000
+DTEND:20260205T200000
+UID:0990ef2aba51c0b2c14fc09976b79c13@copperfieldsbooks.com
+DESCRIPTION:PetalumaKids Event\, Petaluma\, Kids Event. PETALUMA --\n \nC
+ elebrate the release of Rumpelstiltskin in Petaluma with award-winning\,
+  New York Times bestselling authors (and National Ambassador of Young Pe
+ oples L...\n\nMore info: https://copperfieldsbooks.com/event/2026-02-05/ma
+ c-barnett-carson-ellis
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-05/mac-barnett-carson-elli
+ s
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:AARON REYNOLDS M&G
+DTSTART:20260206T180000
+DTEND:20260206T200000
+UID:47813d1102e68319be3380330f6af20b@copperfieldsbooks.com
+DESCRIPTION:Meet and GreetKids EventPetaluma\, Meet and Greet\, Kids Event
+ \, Petaluma. PETALUMA --\nMeet and greet with the hilarious (and creepy!) 
+ author Aaron Reynolds featuring his newest book Jasper Rabbits Creepy Tale
+ s: Unsettling Salad!\nDrop by our Petaluma store on Friday\, Febr...\n\nMo
+ re info: https://copperfieldsbooks.com/event/2026-02-06/aaron-reynolds-mg
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-06/aaron-reynolds-mg
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:NICK OFFERMAN: BIG WOODCHUCK
+DTSTART:20260206T180000
+DTEND:20260206T200000
+UID:e8b586f84c12ffaba507e59af5275f96@copperfieldsbooks.com
+DESCRIPTION:Luther Burbank Center for the Arts 50 Mark West Springs Road S
+ anta Rosa \, CA 95403 United States\n\nMore info: https://copperfieldsbook
+ s.com/event/2026-02-06/nick-offerman-big-woodchuck
+LOCATION:Copperfield's Books
+URL:https://copperfieldsbooks.com/event/2026-02-06/nick-offerman-big-woodc
+ huck
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:PAULA MCLAIN & REBECCA PLOTNICK
+DTSTART:20260207T180000
+DTEND:20260207T200000
+UID:29770367911bcb6ee37e9024da60434b@copperfieldsbooks.com
+DESCRIPTION:Healdsburg\, Healdsburg. Little Saint - Healdsburg 25 North St
+ reet Healdsburg \, CA 95448 United States\n\nMore info: https://copperfiel
+ dsbooks.com/event/2026-02-07/paula-mclain-rebecca-plotnick
+LOCATION:Copperfield's Books\, 104 Matheson Street\, Healdsburg\, CA 95448
+URL:https://copperfieldsbooks.com/event/2026-02-07/paula-mclain-rebecca-pl
+ otnick
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:E.K. O'CONNOR M&G
+DTSTART:20260207T180000
+DTEND:20260207T200000
+UID:56dc7d6f6d92cad54ba9d5d94eb10d2f@copperfieldsbooks.com
+DESCRIPTION:SebastopolMeet and Greet\, Sebastopol\, Meet and Greet. SEBAST
+ OPOL --\nMeet and Greet with local author E.K. O'Connor featuring her bran
+ d new stand-alone fantasy novel - She-Wolf - A Saphhic Beowulf Retelling!
+ \nDrop by our Sebastopol store on ...\n\nMore info: https://copperfieldsbo
+ oks.com/event/2026-02-07/ek-oconnor-mg
+LOCATION:Copperfield's Books\, 138 N Main St\, Sebastopol\, CA 95472
+URL:https://copperfieldsbooks.com/event/2026-02-07/ek-oconnor-mg
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:RANDALL BALMER M&G
+DTSTART:20260207T180000
+DTEND:20260207T200000
+UID:cd4d38822676b62baadb4aefd740d582@copperfieldsbooks.com
+DESCRIPTION:NapaMeet and Greet\, Napa\, Meet and Greet. NAPA --\nMeet and 
+ Greet with Episcopal priest and CNN Contributor Randall Balmer featuring h
+ is latest book - America's Best Idea: The Separation of Church and State.
+  \nDrop by our Napa st...\n\nMore info: https://copperfieldsbooks.com/eve
+ nt/2026-02-07/randall-balmer-mg
+LOCATION:Copperfield's Books\, 1300 First Street Suite 398\, Napa\, CA 945
+ 58
+URL:https://copperfieldsbooks.com/event/2026-02-07/randall-balmer-mg
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:JAMES RILEY M&G
+DTSTART:20260210T180000
+DTEND:20260210T200000
+UID:b8a4908ce9daae8a4894400261cb1683@copperfieldsbooks.com
+DESCRIPTION:Kids EventPetalumaMeet and Greet\, Kids Event\, Petaluma\, Mee
+ t and Greet. PETALUMA -- \nOn Tuesday\, February 10th\, we are delighted 
+ to welcome bestselling author James Riley\, here to talk about his newest 
+ book\, Dragon's Apprentice: The Revenants Return. James' books ...\n\nMore
+  info: https://copperfieldsbooks.com/event/2026-02-10/james-riley-mg
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-10/james-riley-mg
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:JASMIN ‘IOLANI HAKES
+DTSTART:20260213T180000
+DTEND:20260213T200000
+UID:79668ab9845a8f959290b28598830d2a@copperfieldsbooks.com
+DESCRIPTION:Montgomery Village (Santa Rosa)\, Montgomery Village (Santa Ro
+ sa). SANTA ROSA --\nCopperfield’s Books welcomes award-winning author J
+ asmin ‘Iolani Hakes to Montgomery Village for her stunning new novel - 
+ The Pohaku.\nEmbrace the Aloha spirit wit...\n\nMore info: https://copperf
+ ieldsbooks.com/event/2026-02-13/jasmin-iolani-hakes
+LOCATION:Copperfield's Books\, 2316 Montgomery Drive\, Santa Rosa\, CA 954
+ 05
+URL:https://copperfieldsbooks.com/event/2026-02-13/jasmin-iolani-hakes
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:AUTHOR & MUSICIAN ROBBIE ARNETT!
+DTSTART:20260217T180000
+DTEND:20260217T200000
+UID:f48081c0b84755bde4944668ec8dc0ea@copperfieldsbooks.com
+DESCRIPTION:PetalumaKids Event\, Petaluma\, Kids Event. PETALUMA --\nWelco
+ me Robbie Arnett!\nOn Tuesday\, February 17th\, we are delighted to host a
+  lively and musical storytime with author Robbie Arnett\, here to talk abo
+ ut his new picture book\, Thwistle Pi...\n\nMore info: https://copperfield
+ sbooks.com/event/2026-02-17/author-musician-robbie-arnett
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-17/author-musician-robbie-
+ arnett
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:EIRINIE CARSON
+DTSTART:20260220T180000
+DTEND:20260220T200000
+UID:6019826834f2bfcb9fb8f90365a57170@copperfieldsbooks.com
+DESCRIPTION:Petaluma\, Petaluma. PETALUMA --\nCopperfield's Books welcomes
+  friend and beloved local author Eirinie Carson to Petaluma for the launch
+  of her hypnotic new Gothic thriller - Bloodfire\, Baby: A Novel! \n...\
+ n\nMore info: https://copperfieldsbooks.com/event/2026-02-20/eirinie-carso
+ n
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-20/eirinie-carson
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:ERIC MAISEL & JULIANA BRUNO
+DTSTART:20260220T180000
+DTEND:20260220T200000
+UID:97845561adf218c7e63612aa69e2674f@copperfieldsbooks.com
+DESCRIPTION:Sebastopol\, Sebastopol. SEBASTOPOL --\nCopperfield’s Books 
+ welcomes internationally recognized coach and local author Eric Maisel to
+  Sebastopol in celebration of his incisive and urgent new book - Brave New
+  M...\n\nMore info: https://copperfieldsbooks.com/event/2026-02-20/eric-ma
+ isel-juliana-bruno
+LOCATION:Copperfield's Books\, 138 N Main St\, Sebastopol\, CA 95472
+URL:https://copperfieldsbooks.com/event/2026-02-20/eric-maisel-juliana-bru
+ no
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:DAISY HERNÁNDEZ
+DTSTART:20260222T180000
+DTEND:20260222T200000
+UID:4c77c3f50475b1bd527503257db38a1b@copperfieldsbooks.com
+DESCRIPTION:San Rafael\, San Rafael. SAN RAFAEL --\nCopperfield's Books is
+  honored to welcome Daisy Hernández to San Rafael for her critical new b
+ ook - Citizenship: Notes on an American Myth.\nJoin us for a timely...\n
+ \nMore info: https://copperfieldsbooks.com/event/2026-02-22/daisy-hernande
+ z
+LOCATION:Copperfield's Books\, 850 Fourth Street\, San Rafael\, CA 94901
+URL:https://copperfieldsbooks.com/event/2026-02-22/daisy-hernandez
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:MYCHAL THREETS M&G
+DTSTART:20260225T180000
+DTEND:20260225T200000
+UID:711095f179972d8326bc112e613ae741@copperfieldsbooks.com
+DESCRIPTION:PetalumaMeet and Greet\, Petaluma\, Meet and Greet. PETALUMA -
+ -\nMeet and Greet with celebrated librarian and literary ambassador Mychal
+  Threets featuring his adventurous new picture book - I'm So Happy You're
+  Here: A Celebration of Libra...\n\nMore info: https://copperfieldsbooks.c
+ om/event/2026-02-25/mychal-threets-mg
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-25/mychal-threets-mg
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:OLIVER JAMES & MYCHAL THREETS
+DTSTART:20260226T180000
+DTEND:20260226T200000
+UID:4431d0796864a02963bd9dfddcd18e4f@copperfieldsbooks.com
+DESCRIPTION:Petaluma\, Petaluma. PETALUMA --\nCopperfield's Books and Read
+  On Sonoma are honored to welcome literacy advocate and motivational speak
+ er Oliver James for the launch of his powerful new memoir - Unread: A M..
+ .\n\nMore info: https://copperfieldsbooks.com/event/2026-02-26/oliver-jame
+ s-mychal-threets
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-02-26/oliver-james-mychal-thr
+ eets
+END:VEVENT
+END:VCALENDAR

--- a/santarosa/copperfields_2026_03.ics
+++ b/santarosa/copperfields_2026_03.ics
@@ -1,0 +1,46 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Copperfields Books//copperfieldsbooks.com//
+X-WR-CALNAME:Copperfield's Books - 2026/03
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:JENNIFER VAN DER KLEUT
+DTSTART:20260301T180000
+DTEND:20260301T200000
+UID:d0a0bfa8f7558306f55d79ecd60484f3@copperfieldsbooks.com
+DESCRIPTION:Petaluma\, Petaluma. PETALUMA --\nCopperfield's Books welcomes
+  award-winning journalist and Bay Area native Jennifer van der Kleut to 
+ Petaluma in celebration of her propulsive debut thriller - The Better ...
+ \n\nMore info: https://copperfieldsbooks.com/event/2026-03-01/jennifer-van
+ -der-kleut
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-03-01/jennifer-van-der-kleut
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:RACHAEL DEVAUX
+DTSTART:20260314T180000
+DTEND:20260314T200000
+UID:c72b3859c3f5a8d04a3f0863ba9f3c98@copperfieldsbooks.com
+DESCRIPTION:LarkspurRead It & Eat It Influencer Series\, Larkspur\, Read I
+ t & Eat It Influencer Series. LARKSPUR --\nCopperfield’s Books is deligh
+ ted to welcome back New York Times bestselling author and registered dieti
+ cian Rachael DeVaux to Marin Country Mart in celebration of her highly ant
+ icipat...\n\nMore info: https://copperfieldsbooks.com/event/2026-03-14/rac
+ hael-devaux
+LOCATION:Copperfield's Books
+URL:https://copperfieldsbooks.com/event/2026-03-14/rachael-devaux
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:PETER RUSSELL
+DTSTART:20260327T180000
+DTEND:20260327T200000
+UID:649a8bb54a261ff09493a183e5b5bdda@copperfieldsbooks.com
+DESCRIPTION:Sebastopol\, Sebastopol. SEBASTOPOL --\nCopperfield’s Books 
+ welcomes renowned meditation teacher Peter Russell to Sebastopol in celeb
+ ration of his new book - How to Meditate Without Even Trying (Eckhart Toll
+ e Edition...\n\nMore info: https://copperfieldsbooks.com/event/2026-03-27/
+ peter-russell
+LOCATION:Copperfield's Books\, 138 N Main St\, Sebastopol\, CA 95472
+URL:https://copperfieldsbooks.com/event/2026-03-27/peter-russell
+END:VEVENT
+END:VCALENDAR

--- a/santarosa/copperfields_2026_04.ics
+++ b/santarosa/copperfields_2026_04.ics
@@ -1,0 +1,20 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Copperfields Books//copperfieldsbooks.com//
+X-WR-CALNAME:Copperfield's Books - 2026/04
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:MARISSA MEYER & TAMARA MOSS
+DTSTART:20260406T180000
+DTEND:20260406T200000
+UID:9477b84290fe1efe7287ff1ce331d73a@copperfieldsbooks.com
+DESCRIPTION:PetalumaTeen Event\, Petaluma\, Teen Event. PETALUMA --\nCeleb
+ rate the release of The Escape Game in Petaluma with award-winning\, New Y
+ ork Times bestselling author Marissa Meyers and rising star Tamara Moss!\n
+ An unforgettable YA murder mystery...\n\nMore info: https://copperfieldsbo
+ oks.com/event/2026-04-06/marissa-meyer-tamara-moss
+LOCATION:Copperfield's Books\, 140 Kentucky Street\, Petaluma\, CA 94952
+URL:https://copperfieldsbooks.com/event/2026-04-06/marissa-meyer-tamara-mo
+ ss
+END:VEVENT
+END:VCALENDAR

--- a/santarosa/feeds.txt
+++ b/santarosa/feeds.txt
@@ -24,3 +24,18 @@ santarosa/SRCity_Main_Calendar.ics
 santarosa/SRCity_City_Offices_Closed.ics
 santarosa/SRCity_Recreation_and_Parks.ics
 santarosa/SRCity_Events.ics
+
+# Sonoma County Parks
+santarosa/sonoma_parks_2026_02.ics
+santarosa/sonoma_parks_2026_03.ics
+santarosa/sonoma_parks_2026_04.ics
+
+# California Theatre
+santarosa/cal_theatre_2026_02.ics
+santarosa/cal_theatre_2026_03.ics
+santarosa/cal_theatre_2026_04.ics
+
+# Copperfield's Books (multiple locations)
+santarosa/copperfields_2026_02.ics
+santarosa/copperfields_2026_03.ics
+santarosa/copperfields_2026_04.ics

--- a/santarosa/sonoma_parks_2026_02.ics
+++ b/santarosa/sonoma_parks_2026_02.ics
@@ -1,0 +1,377 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sonoma County Regional Parks//parks.sonomacounty.ca.gov//
+X-WR-CALNAME:Sonoma County Parks - 2026/02
+X-WR-TIMEZONE:America/Los_Angeles
+BEGIN:VEVENT
+SUMMARY:Bilingual Dog Training
+DTSTART:20260203T160000
+DTEND:20260203T173000
+UID:aff365cd894a1afea4d5c6663ceb34ef@parks.sonomacounty.ca.gov
+DESCRIPTION:February 3\, 2026|4:00 pm - 5:30 pm|Andy's Unity Park
+LOCATION:Andy's Unity Park A free dog training session offered in Spanish 
+ and English.
+URL:https://secure.sonomacountyparks.org/registration/bilingual-dog-traini
+ ng-F253
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Senior Saunter
+DTSTART:20260203T100000
+DTEND:20260203T120000
+UID:6ad907fc429dc53d33acbb25beed7969@parks.sonomacounty.ca.gov
+DESCRIPTION:February 3\, 2026|10:00 am - 12:00 pm|Santa Rosa Creek Trail
+LOCATION:Santa Rosa Creek Trail Senior Saunters are low-impact hikes desig
+ ned to connect older adults with beautiful parks and each other.
+URL:https://secure.sonomacountyparks.org/registration/senior-saunter-F25-3
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Ice Plant Removal Workday
+DTSTART:20260204T093000
+DTEND:20260204T123000
+UID:ce8ae56d249a08e1ca83f8aeae6abcbb@parks.sonomacounty.ca.gov
+DESCRIPTION:February 4\, 2026|9:30 am - 12:30 pm|Doran Regional Park
+LOCATION:Doran Regional Park Join the California Native Plant Society for 
+ a rewarding volunteer workday at Doran Park! Help us remove invasive ice p
+ lants\, preserving the natural habitat.
+URL:https://secure.sonomacountyparks.org/registration/ice-plant-removal-wo
+ rkday-F259
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Hikes with Hounds
+DTSTART:20260205T160000
+DTEND:20260205T173000
+UID:baf547625dcd5c5f0b307560cb289749@parks.sonomacounty.ca.gov
+DESCRIPTION:February 5\, 2026|4:00 pm - 5:30 pm|Helen Putnam Regional Park
+LOCATION:Helen Putnam Regional Park Want to learn how to train the best fo
+ ur-legged hiking partner you could ever have?
+URL:https://secure.sonomacountyparks.org/registration/hikes-with-hounds-F2
+ 53
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Nature Hike
+DTSTART:20260206T140000
+DTEND:20260206T160000
+UID:02d329f7157e74a516c1be2597591046@parks.sonomacounty.ca.gov
+DESCRIPTION:February 6\, 2026|2:00 pm - 4:00 pm|Taylor Mountain Regional P
+ ark and Preserve
+LOCATION:Taylor Mountain Regional Park and Preserve Explore and learn abou
+ t Sonoma County ecosystems.
+URL:https://secure.sonomacountyparks.org/registration/nature-hikeF251
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Wild Words Book Club: Otherlands
+DTSTART:20260206T150000
+DTEND:20260206T160000
+UID:dc99c26351969b7cd4d970680d794d72@parks.sonomacounty.ca.gov
+DESCRIPTION:February 6\, 2026|3:00 pm - 4:00 pm
+URL:https://secure.sonomacountyparks.org/registration/wild-words-book-club
+ -otherlands
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Invasive Plant Removal Workday
+DTSTART:20260207T090000
+DTEND:20260207T120000
+UID:4785a02c8d6c92cb8882a3fa681b2b8f@parks.sonomacounty.ca.gov
+DESCRIPTION:February 7\, 2026|9:00 am - 12:00 pm|Sonoma Valley Regional Pa
+ rk
+LOCATION:Sonoma Valley Regional Park Dig in at Sonoma Valley Regional Park
+  and help us remove invasive plants to give our native plants room to thri
+ ve.
+URL:https://secure.sonomacountyparks.org/registration/invasive-plant-remov
+ al-workday1
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Painting in the Park: Introduction to Watercolor
+DTSTART:20260207T100000
+DTEND:20260207T120000
+UID:ed63578a06ee62bc2625fc86a4b875ce@parks.sonomacounty.ca.gov
+DESCRIPTION:February 7\, 2026|10:00am - 12:00pm|Running Fence Watson Schoo
+ l Historic Park
+LOCATION:Running Fence Watson School Historic Park Practice composition an
+ d color in this introduction to watercolor painting class
+URL:https://secure.sonomacountyparks.org/registration/painting-in-the-park
+ -introduction-to-watercolor
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Watson School Open House
+DTSTART:20260207T100000
+DTEND:20260207T140000
+UID:053172d104acfb91e4be8cc18304cbcb@parks.sonomacounty.ca.gov
+DESCRIPTION:February 7\, 2026|10:00am - 2:00pm|Running Fence Watson School
+  Historic Park
+LOCATION:Running Fence Watson School Historic Park Get a glimpse of what l
+ ife was like in a one-room schoolhouse.
+URL:https://secure.sonomacountyparks.org/registration/watson-school-open-h
+ ouseW26
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Park Preview: Wright Hill (10:00 am session)
+DTSTART:20260207T100000
+DTEND:20260207T120000
+UID:d395fc0522018d0050934834d9ea6d13@parks.sonomacounty.ca.gov
+DESCRIPTION:February 7\, 2026|10:00 am - 12:00 pm|Wright Hill Ranch Region
+ al Park and Preserve
+LOCATION:Wright Hill Ranch Regional Park and Preserve Explore one of Sonom
+ a County's newest parklands before it opens to the public.
+URL:https://secure.sonomacountyparks.org/registration/park-preview-wright-
+ hill-26.02.07.1
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Park Preview: Wright Hill (10:45 am session)
+DTSTART:20260207T104500
+DTEND:20260207T124500
+UID:f267a6cf71948cc7f86db23ad78c4b4d@parks.sonomacounty.ca.gov
+DESCRIPTION:February 7\, 2026|10:45 am - 12:45 pm|Wright Hill Ranch Region
+ al Park and Preserve
+LOCATION:Wright Hill Ranch Regional Park and Preserve Explore one of Sonom
+ a County's newest parklands before it opens to the public.
+URL:https://secure.sonomacountyparks.org/registration/park-preview-wright-
+ hill-26.02.07.2
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Park Preview: Wright Hill (11:30 am session)
+DTSTART:20260207T113000
+DTEND:20260207T133000
+UID:862afe581f0aac083cfdba982f426304@parks.sonomacounty.ca.gov
+DESCRIPTION:February 7\, 2026|11:30 am - 1:30 pm|Wright Hill Ranch Regiona
+ l Park and Preserve
+LOCATION:Wright Hill Ranch Regional Park and Preserve Explore one of Sonom
+ a County's newest parklands before it opens to the public.
+URL:https://secure.sonomacountyparks.org/registration/park-preview-wright-
+ hill-26.02.07.3
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Park Preview: Wright Hill (12:30 pm session)
+DTSTART:20260207T123000
+DTEND:20260207T143000
+UID:377f335bbaf79f2cc0fb32f0df22a9bd@parks.sonomacounty.ca.gov
+DESCRIPTION:February 7\, 2026|12:30 pm - 2:30 pm|Wright Hill Ranch Regiona
+ l Park and Preserve
+LOCATION:Wright Hill Ranch Regional Park and Preserve Explore one of Sonom
+ a County's newest parklands before it opens to the public.
+URL:https://secure.sonomacountyparks.org/registration/park-preview-wright-
+ hill-26.02.07.4
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Feelin' Crabby
+DTSTART:20260208T110000
+DTEND:20260208T133000
+UID:16c5e7908b5480f6a4c70e1ae9130837@parks.sonomacounty.ca.gov
+DESCRIPTION:February 8\, 2026|11:00 am - 1:30 pm|Spud Point Marina
+URL:https://secure.sonomacountyparks.org/registration/feelin-crabby-F255
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Ice Plant Removal Workday
+DTSTART:20260211T093000
+DTEND:20260211T123000
+UID:446ae4fa31679616405c6a7d5f82d836@parks.sonomacounty.ca.gov
+DESCRIPTION:February 11\, 2026|9:30 am - 12:30 pm|Doran Regional Park
+LOCATION:Doran Regional Park Join the California Native Plant Society for 
+ a rewarding volunteer workday at Doran Park! Help us remove invasive ice p
+ lants\, preserving the natural habitat.
+URL:https://secure.sonomacountyparks.org/registration/ice-plant-removal-wo
+ rkday-F2510
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Newt Commute
+DTSTART:20260213T100000
+DTEND:20260213T120000
+UID:28e3d4fb8aeb32787ac1349bd7eb5b65@parks.sonomacounty.ca.gov
+DESCRIPTION:February 13\, 2026|10:00 am - 12:00 pm|Monte Rio Redwoods Regi
+ onal Park and Preserve
+LOCATION:Monte Rio Redwoods Regional Park and Preserve Come find out who's
+  walking around in the woods!
+URL:https://secure.sonomacountyparks.org/registration/newt-commute-W252
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Fire Ecology Hike: Shaped by Fire
+DTSTART:20260214T093000
+DTEND:20260214T123000
+UID:593ed196523fea29770cb773b802f1e1@parks.sonomacounty.ca.gov
+DESCRIPTION:February 14\, 2026|9:30 am - 12:30 pm|Mark West Creek Regional
+  Park and Preserve
+LOCATION:Mark West Creek Regional Park and Preserve Come discover how fire
+  is an inseparable part of the California landscape.
+URL:https://secure.sonomacountyparks.org/registration/fire-ecology-hike-sh
+ aped-by-fire
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Science Saturday: Marble Mazes 1-2pm
+DTSTART:20260214T130000
+DTEND:20260214T140000
+UID:3d78cdb42fe93b84e6587413cf97ab86@parks.sonomacounty.ca.gov
+DESCRIPTION:February 14\, 2026|1:00 pm - 2:00 pm|Environmental Discovery C
+ enter Spring Lake Regional Park
+LOCATION:Environmental Discovery Center Spring Lake Regional Park Bring yo
+ ur junior scientist over to the EDC to enjoy a kids-only\, interactive sci
+ ence and art hour.
+URL:https://secure.sonomacountyparks.org/registration/science-saturday-mar
+ ble-mazes-12pmW25
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Science Saturday: Marble Mazes 11am- 12pm
+DTSTART:20260214T110000
+DTEND:20260214T120000
+UID:e1804369382c8cb10105d87b2a2b201d@parks.sonomacounty.ca.gov
+DESCRIPTION:February 14\, 2026|11:00 am - 12:00 pm|Environmental Discovery
+  Center Spring Lake Regional Park
+LOCATION:Environmental Discovery Center Spring Lake Regional Park Bring yo
+ ur junior scientist over to the EDC to enjoy a kids-only\, interactive sci
+ ence and art hour.
+URL:https://secure.sonomacountyparks.org/registration/science-saturday-mar
+ ble-mazes-11am-12pmW25
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Parks After Dark: Adapting to Darkness
+DTSTART:20260217T163000
+DTEND:20260217T183000
+UID:6713815919c2a7d39dd5004083de4e8a@parks.sonomacounty.ca.gov
+DESCRIPTION:February 17\, 2026|4:30 pm - 6:30 pm|Sonoma Valley Regional Pa
+ rk
+LOCATION:Sonoma Valley Regional Park Engage with the beautiful and often u
+ nseen world of parks after dark!
+URL:https://secure.sonomacountyparks.org/registration/parks-after-dark-ada
+ pting-to-darknessW25
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Ice Plant Removal Workday
+DTSTART:20260218T093000
+DTEND:20260218T123000
+UID:5c2b97e9eeb33925603fb5cdc8b31316@parks.sonomacounty.ca.gov
+DESCRIPTION:February 18\, 2026|9:30 am - 12:30 pm|Doran Regional Park
+LOCATION:Doran Regional Park Join the California Native Plant Society for 
+ a rewarding volunteer workday at Doran Park! Help us remove invasive ice p
+ lants\, preserving the natural habitat.
+URL:https://secure.sonomacountyparks.org/registration/ice-plant-removal-wo
+ rkday-F2511
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Volunteer Workday
+DTSTART:20260218T100000
+DTEND:20260218T120000
+UID:679829e9ae1fb84b50f25302606eb075@parks.sonomacounty.ca.gov
+DESCRIPTION:February 18\, 2026|10:00 am - 12:00 pm|Spring Lake Regional Pa
+ rk
+LOCATION:Spring Lake Regional Park Join us for a rewarding volunteer workd
+ ay at Spring Lake Park\, where you’ll help pick up litter\, improve trai
+ ls\, and repair park infrastructure.
+URL:https://secure.sonomacountyparks.org/registration/volunteer-workdayW25
+ 3
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Rainbow Hike
+DTSTART:20260220T133000
+DTEND:20260220T160000
+UID:128e70120a3f36258e8334bf1276c434@parks.sonomacounty.ca.gov
+DESCRIPTION:February 20\, 2026|1:30 pm - 4:00 pm|Taylor Mountain Regional 
+ Park and Preserve
+LOCATION:Taylor Mountain Regional Park and Preserve This space is provided
+  for intergenerational LGBTQIA2S+ people to come together\, explore the na
+ tural world\, and build community.
+URL:https://secure.sonomacountyparks.org/registration/rainbow-hikeW252
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Vista Hike: Hood Mountain
+DTSTART:20260221T093000
+DTEND:20260221T123000
+UID:59abc57785856689a54156109930646c@parks.sonomacounty.ca.gov
+DESCRIPTION:February 21\, 2026|9:30 am - 12:30 pm|Hood Mountain Regional P
+ ark and Preserve
+LOCATION:Hood Mountain Regional Park and Preserve Explore the beautiful vi
+ ews and vistas of Sonoma County!
+URL:https://secure.sonomacountyparks.org/registration/vista-hike-hood-moun
+ tain
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Tide Pool Talk
+DTSTART:20260222T130000
+DTEND:20260222T140000
+UID:8d4de3d88629160566cb7a48766297de@parks.sonomacounty.ca.gov
+DESCRIPTION:February 22\, 2026|1:00 pm - 2:00 pm|Doran Regional Park
+LOCATION:Doran Regional Park Learn about the diversity of the rocky shorel
+ ine in this family friendly\, hands-on presentation.
+URL:https://secure.sonomacountyparks.org/registration/tide-pool-talkW25
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Ice Plant Removal Workday
+DTSTART:20260225T093000
+DTEND:20260225T123000
+UID:7def9a2159c62332ded7e02236be0bff@parks.sonomacounty.ca.gov
+DESCRIPTION:February 25\, 2026|9:30 am - 12:30 pm|Doran Regional Park
+LOCATION:Doran Regional Park Join the California Native Plant Society for 
+ a rewarding volunteer workday at Doran Park! Help us remove invasive ice p
+ lants\, preserving the natural habitat.
+URL:https://secure.sonomacountyparks.org/registration/ice-plant-removal-wo
+ rkday-F2512
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Winging it Wednesday
+DTSTART:20260225T083000
+DTEND:20260225T103000
+UID:427d92436d0fe843fa82429a6e102e54@parks.sonomacounty.ca.gov
+DESCRIPTION:February 25\, 2026|8:30 am - 10:30 am|Spud Point Marina
+URL:https://secure.sonomacountyparks.org/registration/winging-it-wednesday
+ -26.2
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Stewardship Workday: Planting for Habitat
+DTSTART:20260226T090000
+DTEND:20260226T120000
+UID:993ac45348d17a752f8457f7969eb6b9@parks.sonomacounty.ca.gov
+DESCRIPTION:February 26\, 2026|9:00 am - 12:00 pm|Shiloh Ranch Regional Pa
+ rk
+LOCATION:Shiloh Ranch Regional Park Help restore the local ecosystem by pl
+ anting native plants.
+URL:https://secure.sonomacountyparks.org/registration/stewardship-workday-
+ planting-for-habitat-26.2
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Saturday Walk in the Park
+DTSTART:20260228T103000
+DTEND:20260228T113000
+UID:71fb25839580ba3fb760d5883488e917@parks.sonomacounty.ca.gov
+DESCRIPTION:February 28\, 2026|10:30 am - 11:30 am|Gualala Point Regional 
+ Park
+LOCATION:Gualala Point Regional Park Explore the natural history of this N
+ orth Coast park and beach.
+URL:https://secure.sonomacountyparks.org/registration/saturday-walk-in-the
+ -park--gualala-point-park-F252
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Invasive Plant Removal Workday
+DTSTART:20260228T090000
+DTEND:20260228T120000
+UID:846e2c081a4fa716c1758f1c22bc594d@parks.sonomacounty.ca.gov
+DESCRIPTION:February 28\, 2026|9:00 am - 12:00 pm|Shiloh Ranch Regional Pa
+ rk
+LOCATION:Shiloh Ranch Regional Park Dig in at Shiloh Ranch Regional Park a
+ nd help us remove invasive plants to give our native plants room to thrive
+ .
+URL:https://secure.sonomacountyparks.org/registration/invasive-plant-remov
+ al-workday2
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Nuestros Parques: Let’s Climb a Mountain!
+DTSTART:20260228T100000
+DTEND:20260228T130000
+UID:b63440e70b0395e8d7744c7812669def@parks.sonomacounty.ca.gov
+DESCRIPTION:February 28\, 2026|10:00 am - 1:00 pm|Monte Rio Redwoods Regio
+ nal Park and Preserve
+LOCATION:Monte Rio Redwoods Regional Park and Preserve Bilingual hikes and
+  community events for the whole family!
+URL:https://secure.sonomacountyparks.org/registration/nuestros-parques-let
+ s-climb-a-mountain-W25
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Tide Pool Adventure
+DTSTART:20260228T143000
+DTEND:20260228T163000
+UID:0d3830dc0e45983116a9fb51db2c07c9@parks.sonomacounty.ca.gov
+DESCRIPTION:February 28\, 2026|2:30 pm - 4:30 pm|Pinnacle Gulch Coastal Ac
+ cess Trail
+LOCATION:Pinnacle Gulch Coastal Access Trail Join us to explore the amazin
+ g underwater world of tide pools!
+URL:https://secure.sonomacountyparks.org/registration/tide-pool-adventureW
+ 25
+END:VEVENT
+END:VCALENDAR

--- a/santarosa/sonoma_parks_2026_03.ics
+++ b/santarosa/sonoma_parks_2026_03.ics
@@ -1,0 +1,6 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sonoma County Regional Parks//parks.sonomacounty.ca.gov//
+X-WR-CALNAME:Sonoma County Parks - 2026/03
+X-WR-TIMEZONE:America/Los_Angeles
+END:VCALENDAR

--- a/santarosa/sonoma_parks_2026_04.ics
+++ b/santarosa/sonoma_parks_2026_04.ics
@@ -1,0 +1,6 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sonoma County Regional Parks//parks.sonomacounty.ca.gov//
+X-WR-CALNAME:Sonoma County Parks - 2026/04
+X-WR-TIMEZONE:America/Los_Angeles
+END:VCALENDAR

--- a/scrapers/README.md
+++ b/scrapers/README.md
@@ -1,0 +1,64 @@
+# Event Scrapers
+
+Python scrapers for extracting events from various Sonoma County venues that don't provide standard iCal feeds.
+
+## Scrapers
+
+### sonoma_parks.py
+Sonoma County Regional Parks calendar
+- URL: https://parks.sonomacounty.ca.gov/play/calendar
+- Events: Hikes, nature programs, volunteer workdays
+- Method: HTML scraping (server-rendered calendar)
+
+### redwood_cafe.py  
+Redwood Cafe Cotati live music
+- URL: https://redwoodcafecotati.com/events/
+- Events: Live music performances
+- Method: WordPress My Calendar plugin HTML scraping
+
+### cal_theatre.py
+California Theatre Santa Rosa
+- URL: https://www.caltheatre.com/calendar  
+- Events: Concerts, theater, comedy shows
+- Method: Wix calendar widget HTML scraping
+- Note: Works with static fetch; --use-selenium option available for JS rendering
+
+### copperfields.py
+Copperfield's Books (multiple locations)
+- URL: https://copperfieldsbooks.com/upcoming-events
+- Events: Author readings, book signings, kids events
+- Locations: Petaluma, Sebastopol, Healdsburg, San Rafael, Napa, Calistoga, Montgomery Village
+- Method: Drupal HTML scraping
+
+## Usage
+
+Each scraper accepts `--year` and `--month` arguments and outputs an ICS file:
+
+```bash
+python3 sonoma_parks.py --year 2026 --month 2 --output sonoma_parks_2026_02.ics
+python3 redwood_cafe.py --year 2026 --month 2 --output redwood_cafe_2026_02.ics
+python3 cal_theatre.py --year 2026 --month 2 --output cal_theatre_2026_02.ics
+python3 copperfields.py --year 2026 --month 2 --output copperfields_2026_02.ics
+```
+
+## Dependencies
+
+- requests
+- beautifulsoup4
+- icalendar
+
+Optional for cal_theatre.py with --use-selenium:
+- selenium
+- Chrome/Chromium browser
+
+## Output Locations
+
+- santarosa/: sonoma_parks, cal_theatre, copperfields
+- cotati/: redwood_cafe
+- sebastopol/: sebarts (existing), occidental_arts (existing)
+
+## Notes
+
+- Events for future months may be empty if the venue hasn't posted them yet
+- Most venues post events 1-2 months in advance
+- SebArts (sebastopol/sebarts.py) was already implemented in the project

--- a/scrapers/cal_theatre.py
+++ b/scrapers/cal_theatre.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Scraper for California Theatre (Cal Theatre) Santa Rosa events
+https://www.caltheatre.com/calendar
+
+This is a Wix site with a calendar widget. We need to use browser automation
+or parse the rendered HTML since data is loaded via JavaScript.
+"""
+
+import requests
+from bs4 import BeautifulSoup
+from icalendar import Calendar, Event
+from datetime import datetime, timedelta
+import re
+import argparse
+import logging
+import hashlib
+import json
+import time
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+BASE_URL = 'https://www.caltheatre.com'
+CALENDAR_URL = f'{BASE_URL}/calendar'
+VENUE_ADDRESS = "California Theatre, 528 7th St, Santa Rosa, CA 95401"
+
+def fetch_with_selenium(year, month):
+    """Fetch calendar page using Selenium for JavaScript rendering."""
+    try:
+        from selenium import webdriver
+        from selenium.webdriver.chrome.options import Options
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.support.ui import WebDriverWait
+        from selenium.webdriver.support import expected_conditions as EC
+    except ImportError:
+        logger.error("Selenium not installed. Install with: pip install selenium")
+        raise
+    
+    chrome_options = Options()
+    chrome_options.add_argument('--headless')
+    chrome_options.add_argument('--no-sandbox')
+    chrome_options.add_argument('--disable-dev-shm-usage')
+    
+    driver = webdriver.Chrome(options=chrome_options)
+    
+    try:
+        driver.get(CALENDAR_URL)
+        
+        # Wait for calendar to load
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, '[data-hook*="calendar"]'))
+        )
+        
+        # Navigate to target month if needed
+        current_month = datetime.now().month
+        current_year = datetime.now().year
+        
+        months_diff = (year - current_year) * 12 + (month - current_month)
+        
+        if months_diff > 0:
+            for _ in range(months_diff):
+                next_btn = driver.find_element(By.CSS_SELECTOR, '[data-hook="calendar-next-month-button"]')
+                next_btn.click()
+                time.sleep(0.5)
+        elif months_diff < 0:
+            for _ in range(abs(months_diff)):
+                prev_btn = driver.find_element(By.CSS_SELECTOR, '[data-hook="calendar-previous-month-button"]')
+                prev_btn.click()
+                time.sleep(0.5)
+        
+        time.sleep(1)  # Wait for calendar update
+        
+        return driver.page_source
+        
+    finally:
+        driver.quit()
+
+def fetch_calendar_static():
+    """Attempt to fetch calendar with static request (may not work for JS sites)."""
+    logger.info(f"Fetching {CALENDAR_URL}")
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+    }
+    response = requests.get(CALENDAR_URL, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+def parse_wix_calendar_text(html_content, target_year, target_month):
+    """Parse events from Wix calendar text content."""
+    soup = BeautifulSoup(html_content, 'html.parser')
+    events = []
+    
+    # Try to find calendar day cells with events
+    # Wix uses data-hook attributes
+    calendar_cells = soup.find_all(attrs={'data-hook': re.compile(r'calendar-day-\d+')})
+    
+    month_names = ['January', 'February', 'March', 'April', 'May', 'June',
+                   'July', 'August', 'September', 'October', 'November', 'December']
+    month_name = month_names[target_month - 1]
+    
+    for cell in calendar_cells:
+        try:
+            cell_text = cell.get_text(' ', strip=True)
+            
+            # Extract day number from data-hook like "calendar-day-15"
+            hook = cell.get('data-hook', '')
+            day_match = re.search(r'calendar-day-(\d+)', hook)
+            if not day_match:
+                continue
+            day = int(day_match.group(1))
+            
+            # Find events in this cell - look for time patterns
+            # Format: "15 7:30 PM Event Title +1 more"
+            event_patterns = re.findall(r'(\d{1,2}:\d{2}\s*(?:AM|PM))\s+([^+]+?)(?:\s*\+|$)', cell_text, re.IGNORECASE)
+            
+            for time_str, title in event_patterns:
+                title = title.strip()
+                if not title or len(title) < 3:
+                    continue
+                
+                try:
+                    date_str = f"{month_name} {day}, {target_year}"
+                    dt_start = datetime.strptime(f"{date_str} {time_str}", "%B %d, %Y %I:%M %p")
+                except ValueError:
+                    continue
+                
+                # Events typically 2-3 hours
+                dt_end = dt_start + timedelta(hours=3)
+                
+                events.append({
+                    'title': title,
+                    'url': CALENDAR_URL,
+                    'dtstart': dt_start,
+                    'dtend': dt_end,
+                    'location': VENUE_ADDRESS,
+                    'description': f'Event at California Theatre. See {CALENDAR_URL} for details.'
+                })
+                
+                logger.info(f"Found event: {title} on {dt_start}")
+        
+        except Exception as e:
+            logger.warning(f"Error parsing cell: {e}")
+            continue
+    
+    return events
+
+def create_calendar(events, year, month):
+    """Create an iCalendar from parsed events."""
+    cal = Calendar()
+    cal.add('prodid', '-//California Theatre Santa Rosa//caltheatre.com//')
+    cal.add('version', '2.0')
+    cal.add('x-wr-calname', f'Cal Theatre - {year}/{month:02d}')
+    cal.add('x-wr-timezone', 'America/Los_Angeles')
+    
+    for event_data in events:
+        event = Event()
+        event.add('summary', event_data['title'])
+        event.add('dtstart', event_data['dtstart'])
+        event.add('dtend', event_data['dtend'])
+        event.add('url', event_data['url'])
+        event.add('location', event_data['location'])
+        event.add('description', event_data['description'])
+        
+        # Generate a UID
+        uid_str = f"{event_data['title']}-{event_data['dtstart'].isoformat()}"
+        uid = hashlib.md5(uid_str.encode()).hexdigest()
+        event.add('uid', f"{uid}@caltheatre.com")
+        
+        cal.add_component(event)
+    
+    return cal
+
+def main():
+    parser = argparse.ArgumentParser(description='Scrape Cal Theatre events')
+    parser.add_argument('--year', type=int, required=True, help='Target year')
+    parser.add_argument('--month', type=int, required=True, help='Target month (1-12)')
+    parser.add_argument('--output', type=str, help='Output filename')
+    parser.add_argument('--use-selenium', action='store_true', help='Use Selenium for JS rendering')
+    args = parser.parse_args()
+    
+    if args.use_selenium:
+        html = fetch_with_selenium(args.year, args.month)
+    else:
+        html = fetch_calendar_static()
+    
+    events = parse_wix_calendar_text(html, args.year, args.month)
+    
+    logger.info(f"Found {len(events)} events for {args.year}-{args.month:02d}")
+    
+    cal = create_calendar(events, args.year, args.month)
+    
+    output_file = args.output or f'cal_theatre_{args.year}_{args.month:02d}.ics'
+    with open(output_file, 'wb') as f:
+        f.write(cal.to_ical())
+    
+    logger.info(f"Written to {output_file}")
+    return output_file
+
+if __name__ == '__main__':
+    main()

--- a/scrapers/copperfields.py
+++ b/scrapers/copperfields.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Scraper for Copperfield's Books events
+https://copperfieldsbooks.com/upcoming-events
+
+Drupal site with clean HTML structure.
+"""
+
+import requests
+from bs4 import BeautifulSoup
+from icalendar import Calendar, Event
+from datetime import datetime, timedelta
+import re
+import argparse
+import logging
+import hashlib
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+BASE_URL = 'https://copperfieldsbooks.com'
+EVENTS_URL = f'{BASE_URL}/upcoming-events'
+
+# Copperfield's store locations
+STORE_LOCATIONS = {
+    'petaluma': '140 Kentucky Street, Petaluma, CA 94952',
+    'sebastopol': '138 N Main St, Sebastopol, CA 95472',
+    'healdsburg': '104 Matheson Street, Healdsburg, CA 95448',
+    'san rafael': '850 Fourth Street, San Rafael, CA 94901',
+    'napa': '1300 First Street Suite 398, Napa, CA 94558',
+    'calistoga': '1330 Lincoln Avenue, Calistoga, CA 94515',
+    'montgomery village': '2316 Montgomery Drive, Santa Rosa, CA 95405',
+}
+
+def fetch_events_page():
+    """Fetch the main events page."""
+    logger.info(f"Fetching {EVENTS_URL}")
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+    }
+    response = requests.get(EVENTS_URL, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+def fetch_event_details(event_url):
+    """Fetch detailed event page."""
+    logger.info(f"Fetching event details: {event_url}")
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+    }
+    try:
+        response = requests.get(event_url, headers=headers, timeout=30)
+        response.raise_for_status()
+        return response.text
+    except Exception as e:
+        logger.warning(f"Could not fetch event details: {e}")
+        return None
+
+def parse_event_detail_page(html_content):
+    """Parse event details from individual event page."""
+    soup = BeautifulSoup(html_content, 'html.parser')
+    details = {}
+    
+    # Get description from meta or content
+    meta_desc = soup.find('meta', {'name': 'description'})
+    if meta_desc:
+        details['description'] = meta_desc.get('content', '')
+    
+    # Look for time info
+    time_elem = soup.find(class_=re.compile(r'time|hour'))
+    if time_elem:
+        details['time_text'] = time_elem.get_text(strip=True)
+    
+    return details
+
+def parse_events(html_content, target_year, target_month):
+    """Parse events from the events listing page."""
+    soup = BeautifulSoup(html_content, 'html.parser')
+    events = []
+    seen_events = set()
+    
+    # Find all event rows
+    for row in soup.find_all('div', class_='views-row'):
+        try:
+            # Get event title and link
+            title_elem = row.find('h2') or row.find('h3') or row.find(class_='title')
+            if not title_elem:
+                continue
+            
+            link = title_elem.find('a') or row.find('a', href=re.compile(r'/event/'))
+            if not link:
+                continue
+            
+            title = title_elem.get_text(strip=True)
+            event_url = link.get('href', '')
+            if not event_url.startswith('http'):
+                event_url = BASE_URL + event_url
+            
+            # Dedupe
+            if event_url in seen_events:
+                continue
+            seen_events.add(event_url)
+            
+            # Get date from the date element
+            date_elem = row.find(class_=re.compile(r'date'))
+            if not date_elem:
+                continue
+            
+            date_text = date_elem.get_text(' ', strip=True)
+            
+            # Parse date: "Feb 03" or similar
+            date_match = re.search(r'([A-Za-z]{3})\s+(\d{1,2})', date_text)
+            if not date_match:
+                continue
+            
+            month_abbr = date_match.group(1)
+            day = int(date_match.group(2))
+            
+            # Convert month abbreviation to number
+            month_map = {'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'may': 5, 'jun': 6,
+                        'jul': 7, 'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12}
+            month = month_map.get(month_abbr.lower())
+            if not month:
+                continue
+            
+            # Infer year - if month is in the past, it might be next year
+            year = target_year
+            
+            # Filter by target month
+            if month != target_month:
+                continue
+            
+            # Get location from tags or text
+            location = None
+            location_text = row.get_text(' ', strip=True).lower()
+            for loc_name, address in STORE_LOCATIONS.items():
+                if loc_name in location_text:
+                    location = f"Copperfield's Books, {address}"
+                    break
+            
+            if not location:
+                location = "Copperfield's Books"  # Default
+            
+            # Get time if available - default to evening
+            time_elem = row.find(class_=re.compile(r'time'))
+            if time_elem:
+                time_text = time_elem.get_text(strip=True)
+                time_match = re.search(r'(\d{1,2}):?(\d{2})?\s*(am|pm)', time_text, re.IGNORECASE)
+                if time_match:
+                    hour = int(time_match.group(1))
+                    minute = int(time_match.group(2) or 0)
+                    ampm = time_match.group(3).lower()
+                    if ampm == 'pm' and hour != 12:
+                        hour += 12
+                    elif ampm == 'am' and hour == 12:
+                        hour = 0
+                    dt_start = datetime(year, month, day, hour, minute)
+                else:
+                    dt_start = datetime(year, month, day, 18, 0)  # Default 6 PM
+            else:
+                dt_start = datetime(year, month, day, 18, 0)  # Default 6 PM
+            
+            # Events typically 1-2 hours
+            dt_end = dt_start + timedelta(hours=2)
+            
+            # Get event type tags
+            tags = []
+            for tag_elem in row.find_all(class_=re.compile(r'tag|category|type')):
+                tag_text = tag_elem.get_text(strip=True)
+                if tag_text and len(tag_text) < 50:
+                    tags.append(tag_text)
+            
+            # Get description snippet
+            desc_elem = row.find('p') or row.find(class_=re.compile(r'desc|body|summary'))
+            description = ''
+            if desc_elem:
+                description = desc_elem.get_text(' ', strip=True)[:500]
+            
+            if tags:
+                description = f"{', '.join(tags)}. {description}"
+            
+            description += f"\n\nMore info: {event_url}"
+            
+            events.append({
+                'title': title,
+                'url': event_url,
+                'dtstart': dt_start,
+                'dtend': dt_end,
+                'location': location,
+                'description': description.strip()
+            })
+            
+            logger.info(f"Found event: {title} on {dt_start}")
+            
+        except Exception as e:
+            logger.warning(f"Error parsing event: {e}")
+            continue
+    
+    return events
+
+def create_calendar(events, year, month):
+    """Create an iCalendar from parsed events."""
+    cal = Calendar()
+    cal.add('prodid', '-//Copperfields Books//copperfieldsbooks.com//')
+    cal.add('version', '2.0')
+    cal.add('x-wr-calname', f"Copperfield's Books - {year}/{month:02d}")
+    cal.add('x-wr-timezone', 'America/Los_Angeles')
+    
+    for event_data in events:
+        event = Event()
+        event.add('summary', event_data['title'])
+        event.add('dtstart', event_data['dtstart'])
+        event.add('dtend', event_data['dtend'])
+        event.add('url', event_data['url'])
+        event.add('location', event_data['location'])
+        event.add('description', event_data['description'])
+        
+        # Generate a UID
+        uid_str = f"{event_data['title']}-{event_data['dtstart'].isoformat()}"
+        uid = hashlib.md5(uid_str.encode()).hexdigest()
+        event.add('uid', f"{uid}@copperfieldsbooks.com")
+        
+        cal.add_component(event)
+    
+    return cal
+
+def main():
+    parser = argparse.ArgumentParser(description="Scrape Copperfield's Books events")
+    parser.add_argument('--year', type=int, required=True, help='Target year')
+    parser.add_argument('--month', type=int, required=True, help='Target month (1-12)')
+    parser.add_argument('--output', type=str, help='Output filename')
+    args = parser.parse_args()
+    
+    html = fetch_events_page()
+    events = parse_events(html, args.year, args.month)
+    
+    logger.info(f"Found {len(events)} events for {args.year}-{args.month:02d}")
+    
+    cal = create_calendar(events, args.year, args.month)
+    
+    output_file = args.output or f'copperfields_{args.year}_{args.month:02d}.ics'
+    with open(output_file, 'wb') as f:
+        f.write(cal.to_ical())
+    
+    logger.info(f"Written to {output_file}")
+    return output_file
+
+if __name__ == '__main__':
+    main()

--- a/scrapers/redwood_cafe.py
+++ b/scrapers/redwood_cafe.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Scraper for Redwood Cafe Cotati events
+https://redwoodcafecotati.com/events/
+
+Uses WordPress "My Calendar" plugin
+"""
+
+import requests
+from bs4 import BeautifulSoup
+from icalendar import Calendar, Event
+from datetime import datetime, timedelta
+import re
+import argparse
+import logging
+import hashlib
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+BASE_URL = 'https://redwoodcafecotati.com'
+EVENTS_URL = f'{BASE_URL}/events/'
+
+VENUE_ADDRESS = "Redwood Cafe, 8240 Old Redwood Hwy, Cotati, CA 94931"
+
+def fetch_events_page(year, month):
+    """Fetch the events page for a specific month."""
+    url = f"{EVENTS_URL}?month={month:02d}&yr={year}"
+    logger.info(f"Fetching {url}")
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+def parse_events(html_content, target_year, target_month):
+    """Parse events from the calendar HTML."""
+    soup = BeautifulSoup(html_content, 'html.parser')
+    events = []
+    
+    # Find calendar event articles
+    for article in soup.find_all('article', class_='calendar-event'):
+        try:
+            # Get event title from button data-modal-title attribute
+            button = article.find('button', class_='mc-modal')
+            if not button:
+                continue
+            
+            title = button.get('data-modal-title', '')
+            if not title:
+                continue
+            
+            # Decode HTML entities
+            title = title.replace('&amp;', '&')
+            
+            # Get time from button text (e.g., "6:00 PM: Cedar Mountain String Band")
+            button_text = button.get_text(' ', strip=True)
+            time_match = re.search(r'(\d{1,2}:\d{2})\s*(AM|PM)', button_text, re.IGNORECASE)
+            
+            # Find the date from the mc-day-date span in the parent structure
+            # The structure is: <span class='mc-date'>...<span class='mc-day-date'>February 5, 2026</span>...</span>
+            # Look in the HTML before this article for the date
+            article_id = article.get('id', '')
+            
+            # Parse day from article ID (e.g., mc_calendar_05_482-calendar-482 -> day 05)
+            day_match = re.search(r'mc_calendar_(\d{2})_', article_id)
+            if not day_match:
+                continue
+            
+            day = int(day_match.group(1))
+            
+            # Construct the date
+            try:
+                event_date = datetime(target_year, target_month, day)
+            except ValueError:
+                logger.warning(f"Invalid date: {target_year}-{target_month}-{day}")
+                continue
+            
+            # Parse time
+            if time_match:
+                time_str = f"{time_match.group(1)} {time_match.group(2)}"
+                try:
+                    time_obj = datetime.strptime(time_str, "%I:%M %p")
+                    dt_start = event_date.replace(hour=time_obj.hour, minute=time_obj.minute)
+                except ValueError:
+                    dt_start = event_date.replace(hour=18, minute=0)  # Default 6 PM
+            else:
+                dt_start = event_date.replace(hour=18, minute=0)  # Default 6 PM
+            
+            # Events typically run 2-3 hours
+            dt_end = dt_start + timedelta(hours=3)
+            
+            events.append({
+                'title': title,
+                'url': EVENTS_URL,
+                'dtstart': dt_start,
+                'dtend': dt_end,
+                'location': VENUE_ADDRESS,
+                'description': f'Live music at Redwood Cafe Cotati.'
+            })
+            
+            logger.info(f"Found event: {title} on {dt_start}")
+            
+        except Exception as e:
+            logger.warning(f"Error parsing event: {e}")
+            continue
+    
+    return events
+
+def create_calendar(events, year, month):
+    """Create an iCalendar from parsed events."""
+    cal = Calendar()
+    cal.add('prodid', '-//Redwood Cafe Cotati//redwoodcafecotati.com//')
+    cal.add('version', '2.0')
+    cal.add('x-wr-calname', f'Redwood Cafe Cotati - {year}/{month:02d}')
+    cal.add('x-wr-timezone', 'America/Los_Angeles')
+    
+    for event_data in events:
+        event = Event()
+        event.add('summary', event_data['title'])
+        event.add('dtstart', event_data['dtstart'])
+        event.add('dtend', event_data['dtend'])
+        event.add('url', event_data['url'])
+        event.add('location', event_data['location'])
+        event.add('description', event_data['description'])
+        
+        # Generate a UID
+        uid_str = f"{event_data['title']}-{event_data['dtstart'].isoformat()}"
+        uid = hashlib.md5(uid_str.encode()).hexdigest()
+        event.add('uid', f"{uid}@redwoodcafecotati.com")
+        
+        cal.add_component(event)
+    
+    return cal
+
+def main():
+    parser = argparse.ArgumentParser(description='Scrape Redwood Cafe events')
+    parser.add_argument('--year', type=int, required=True, help='Target year')
+    parser.add_argument('--month', type=int, required=True, help='Target month (1-12)')
+    parser.add_argument('--output', type=str, help='Output filename')
+    args = parser.parse_args()
+    
+    html = fetch_events_page(args.year, args.month)
+    events = parse_events(html, args.year, args.month)
+    
+    logger.info(f"Found {len(events)} events for {args.year}-{args.month:02d}")
+    
+    cal = create_calendar(events, args.year, args.month)
+    
+    output_file = args.output or f'redwood_cafe_{args.year}_{args.month:02d}.ics'
+    with open(output_file, 'wb') as f:
+        f.write(cal.to_ical())
+    
+    logger.info(f"Written to {output_file}")
+    return output_file
+
+if __name__ == '__main__':
+    main()

--- a/scrapers/sonoma_parks.py
+++ b/scrapers/sonoma_parks.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Scraper for Sonoma County Regional Parks calendar
+https://parks.sonomacounty.ca.gov/play/calendar
+"""
+
+import requests
+from bs4 import BeautifulSoup
+from icalendar import Calendar, Event
+from datetime import datetime
+import re
+import argparse
+import logging
+import hashlib
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+BASE_URL = 'https://parks.sonomacounty.ca.gov'
+CALENDAR_URL = f'{BASE_URL}/play/calendar'
+
+def fetch_calendar_page():
+    """Fetch the main calendar page."""
+    logger.info(f"Fetching {CALENDAR_URL}")
+    response = requests.get(CALENDAR_URL, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+def parse_events(html_content, target_year, target_month):
+    """Parse events from the calendar HTML."""
+    soup = BeautifulSoup(html_content, 'html.parser')
+    events = []
+    
+    # Find all event listings - they're in .listing divs
+    for listing in soup.find_all('div', class_='listing'):
+        try:
+            # Get title and URL
+            title_link = listing.find('h3')
+            if not title_link:
+                title_link = listing.find('h4')
+            if not title_link:
+                continue
+                
+            anchor = title_link.find('a')
+            if not anchor:
+                continue
+                
+            title = anchor.get_text(strip=True)
+            # Clean up "sold out |" prefix
+            title = re.sub(r'^sold out\s*\|\s*', '', title, flags=re.IGNORECASE)
+            url = anchor.get('href', '')
+            
+            # Get event content div
+            content = listing.find('div', class_='content')
+            if not content:
+                continue
+            
+            # Extract date and time from text
+            text = content.get_text(' ', strip=True)
+            
+            # Parse date - format: "February 3, 2026"
+            date_match = re.search(r'(\w+)\s+(\d{1,2}),\s+(\d{4})', text)
+            if not date_match:
+                continue
+                
+            month_name, day, year = date_match.groups()
+            
+            # Parse time - format: "4:00 pm - 5:30 pm" or "10:00 am - 12:00 pm"
+            time_match = re.search(r'(\d{1,2}:\d{2})\s*(am|pm)\s*-\s*(\d{1,2}:\d{2})\s*(am|pm)', text, re.IGNORECASE)
+            
+            if time_match:
+                start_time_str = f"{time_match.group(1)} {time_match.group(2)}"
+                end_time_str = f"{time_match.group(3)} {time_match.group(4)}"
+            else:
+                # Try single time
+                single_time = re.search(r'(\d{1,2}:\d{2})\s*(am|pm)', text, re.IGNORECASE)
+                if single_time:
+                    start_time_str = f"{single_time.group(1)} {single_time.group(2)}"
+                    end_time_str = None
+                else:
+                    start_time_str = "12:00 pm"
+                    end_time_str = None
+            
+            # Parse the datetime
+            try:
+                date_str = f"{month_name} {day}, {year}"
+                dt_start = datetime.strptime(f"{date_str} {start_time_str}", "%B %d, %Y %I:%M %p")
+                if end_time_str:
+                    dt_end = datetime.strptime(f"{date_str} {end_time_str}", "%B %d, %Y %I:%M %p")
+                else:
+                    dt_end = dt_start
+            except ValueError as e:
+                logger.warning(f"Could not parse date/time for '{title}': {e}")
+                continue
+            
+            # Filter by target month
+            if dt_start.year != target_year or dt_start.month != target_month:
+                continue
+            
+            # Get location if present (usually after the pipe)
+            location_match = re.search(r'\|\s*([^|]+?)\s*(?:$|PETALUMA|Description)', text)
+            location = None
+            if location_match:
+                loc_text = location_match.group(1).strip()
+                # Common location patterns
+                if any(word in loc_text.lower() for word in ['park', 'trail', 'regional', 'preserve']):
+                    location = loc_text
+            
+            # Get description (text after the date/time/location info)
+            desc_elem = listing.find('p')
+            description = desc_elem.get_text(strip=True) if desc_elem else ''
+            
+            events.append({
+                'title': title,
+                'url': url,
+                'dtstart': dt_start,
+                'dtend': dt_end,
+                'location': location,
+                'description': description
+            })
+            
+            logger.info(f"Found event: {title} on {dt_start}")
+            
+        except Exception as e:
+            logger.warning(f"Error parsing event: {e}")
+            continue
+    
+    return events
+
+def create_calendar(events, year, month):
+    """Create an iCalendar from parsed events."""
+    cal = Calendar()
+    cal.add('prodid', '-//Sonoma County Regional Parks//parks.sonomacounty.ca.gov//')
+    cal.add('version', '2.0')
+    cal.add('x-wr-calname', f'Sonoma County Parks - {year}/{month:02d}')
+    cal.add('x-wr-timezone', 'America/Los_Angeles')
+    
+    for event_data in events:
+        event = Event()
+        event.add('summary', event_data['title'])
+        event.add('dtstart', event_data['dtstart'])
+        event.add('dtend', event_data['dtend'])
+        event.add('url', event_data['url'])
+        
+        if event_data.get('location'):
+            event.add('location', event_data['location'])
+        if event_data.get('description'):
+            event.add('description', event_data['description'])
+        
+        # Generate a UID
+        uid_str = f"{event_data['title']}-{event_data['dtstart'].isoformat()}"
+        uid = hashlib.md5(uid_str.encode()).hexdigest()
+        event.add('uid', f"{uid}@parks.sonomacounty.ca.gov")
+        
+        cal.add_component(event)
+    
+    return cal
+
+def main():
+    parser = argparse.ArgumentParser(description='Scrape Sonoma County Parks calendar')
+    parser.add_argument('--year', type=int, required=True, help='Target year')
+    parser.add_argument('--month', type=int, required=True, help='Target month (1-12)')
+    parser.add_argument('--output', type=str, help='Output filename')
+    args = parser.parse_args()
+    
+    html = fetch_calendar_page()
+    events = parse_events(html, args.year, args.month)
+    
+    logger.info(f"Found {len(events)} events for {args.year}-{args.month:02d}")
+    
+    cal = create_calendar(events, args.year, args.month)
+    
+    output_file = args.output or f'sonoma_parks_{args.year}_{args.month:02d}.ics'
+    with open(output_file, 'wb') as f:
+        f.write(cal.to_ical())
+    
+    logger.info(f"Written to {output_file}")
+    return output_file
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## New Scrapers

| Source | Scraper | Events | Output |
|--------|---------|--------|--------|
| Sonoma County Parks | `scrapers/sonoma_parks.py` | ~32/month | santarosa/ |
| Redwood Cafe Cotati | `scrapers/redwood_cafe.py` | ~13/month | cotati/ |
| Cal Theatre Santa Rosa | `scrapers/cal_theatre.py` | ~18/month | santarosa/ |
| Copperfield's Books | `scrapers/copperfields.py` | ~15/month | santarosa/ |

## Changes

- **New `scrapers/` directory** with 4 Python scrapers
- **New `cotati/` area** for Cotati events (Redwood Cafe)
- **Updated `santarosa/feeds.txt`** to include new sources
- Generated ICS files for Feb/Mar/Apr 2026

## Notes

- None of these sites expose iCal feeds, all require HTML scraping
- SebArts scraper already existed in `sebastopol/sebarts.py`
- March/April have fewer events (venues post 1-2 months ahead)

## Usage

```bash
python3 scrapers/sonoma_parks.py --year 2026 --month 2
python3 scrapers/redwood_cafe.py --year 2026 --month 2
python3 scrapers/cal_theatre.py --year 2026 --month 2
python3 scrapers/copperfields.py --year 2026 --month 2
```