### PR TITLE
Fix source visibility settings not persisting

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -321,7 +321,7 @@ function toggleSourceAndSave(source, userSettingsData, supabaseUrl, supabaseKey)
     : current.concat([source]);
 
   // Persist to Supabase (fire-and-forget)
-  fetch(supabaseUrl + '/rest/v1/user_settings', {
+  fetch(supabaseUrl + '/rest/v1/user_settings?on_conflict=user_id,city', {
     method: 'POST',
     headers: {
       apikey: supabaseKey,


### PR DESCRIPTION
## Summary
- Add missing `?on_conflict=user_id,city` to the PostgREST upsert URL in `toggleSourceAndSave()`
- Without this, only the first source toggle persists; all subsequent toggles silently fail against the `UNIQUE(user_id, city)` constraint

## Test plan
- [ ] Sign in, open Sources modal, deselect a source
- [ ] Reload the page — the source should remain deselected
- [ ] Toggle it back on, reload — should persist again

🤖 Generated with [Claude Code](https://claude.com/claude-code)