### PR TITLE
Add --timezone flag and MOUNTAIN timezone to MaxPreps

### DIFF
--- a/scrapers/maxpreps.py
+++ b/scrapers/maxpreps.py
@@ -31,6 +31,7 @@ from lib.utils import DEFAULT_HEADERS
 
 
 PACIFIC = ZoneInfo('America/Los_Angeles')
+MOUNTAIN = ZoneInfo('America/Denver')
 EASTERN = ZoneInfo('America/Indiana/Indianapolis')
 
 # Known schools - add more as needed
@@ -242,25 +243,28 @@ def main():
     parser.add_argument('--url', help='Custom MaxPreps events URL')
     parser.add_argument('--name', default='MaxPreps School',
                         help='School name for custom URL')
+    parser.add_argument('--timezone', default=None,
+                        help='IANA timezone for --url mode (e.g., America/Denver). Defaults to America/Los_Angeles.')
     parser.add_argument('--output', '-o', required=True,
                         help='Output ICS file')
     parser.add_argument('--list-schools', action='store_true',
                         help='List all known schools')
-    
+
     args = parser.parse_args()
-    
+
     if args.list_schools:
         print("Known schools:")
         for key, config in KNOWN_SCHOOLS.items():
             print(f"  {key}: {config['name']}")
         return
-    
+
     if args.url:
+        tz = ZoneInfo(args.timezone) if args.timezone else PACIFIC
         config = {
             'name': args.name,
             'url': args.url,
             'location': '',
-            'timezone': PACIFIC,
+            'timezone': tz,
         }
     elif args.school:
         config = KNOWN_SCHOOLS[args.school]


### PR DESCRIPTION
## Summary
- Adds `MOUNTAIN` timezone constant (`America/Denver`) alongside existing `PACIFIC` and `EASTERN`
- Adds `--timezone` CLI flag for `--url` mode, allowing any IANA timezone to be specified
- Previously, `--url` mode always used Pacific time regardless of the school's location

## Use case
Schools outside the Pacific timezone (e.g., Mountain time schools in Utah, Colorado) produce incorrect event times when using `--url` mode. The `--timezone` flag fixes this:

```bash
python scrapers/maxpreps.py --url "https://www.maxpreps.com/ut/moab/grand-county-red-devils/events/" \
    --name "Grand County HS" --timezone America/Denver -o events.ics
```

Known schools in `KNOWN_SCHOOLS` already have their timezone configured, so this flag only applies to `--url` mode.

## Test plan
- [x] Verified with Mountain time school (Grand County HS, Utah)
- [x] Confirmed Pacific time default is preserved when `--timezone` is omitted
- [x] No changes to existing `--school` mode behavior


🤖 Generated with [Claude Code](https://claude.com/claude-code)