### PR TITLE
Add GoDaddy Website Builder calendar scraper library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
   - [Elfsight Calendar](#elfsight-calendar-scraperslibelfsigtpy)
   - [Legistar](#legistar-scraperslegistarpy---city-government-meetings)
   - [Bibliocommons](#bibliocommons-scraperslibbibliocommunspy---library-event-platforms)
+  - [GoDaddy Calendar](#godaddy-calendar-scraperslibgodaddypy---godaddy-website-builder)
 - [Platform-Specific Techniques](#platform-specific-techniques)
   - [SeeTickets Widgets](#seetickets-widgets)
   - [Wix Events](#wix-events)
@@ -260,6 +261,33 @@ To create a new city/library scraper, subclass `BibliocommonsEventsScraper` and 
 - `timezone`
 - optional filters like `audience_ids`, `type_ids`, `program_ids`, `language_ids`
 
+### GoDaddy Calendar (`scrapers/lib/godaddy.py`) - GoDaddy Website Builder
+For sites built with GoDaddy Website Builder that use the calendar/events widget. These sites serve event data from a JSON API at `calendar.apps.secureserver.net` — no headless browser needed.
+
+**Discovery:** Open the site's calendar page in a browser, open DevTools Network tab, and look for a GET request to `calendar.apps.secureserver.net/v1/events/{website_id}/{section_id}/{widget_id}`. The three UUIDs in the URL are what you need.
+
+To create a scraper, subclass `GoDaddyScraper` and set:
+- `website_id`, `section_id`, `widget_id` (from the API URL)
+- `default_location` (fallback when event has no location)
+- `timezone` (IANA timezone string, e.g., `"America/Denver"`)
+
+Example:
+```python
+from lib.godaddy import GoDaddyScraper
+
+class MyVenueScraper(GoDaddyScraper):
+    name = "My Venue"
+    domain = "myvenue.com"
+    website_id = "850abeb2-..."
+    section_id = "9c296a07-..."
+    widget_id = "f33a9bca-..."
+    default_location = "My Venue, 123 Main St, Anytown, CA"
+    timezone = "America/Los_Angeles"
+
+if __name__ == '__main__':
+    MyVenueScraper.main()
+```
+
 ---
 
 ## Platform-Specific Techniques
@@ -270,6 +298,7 @@ To create a new city/library scraper, subclass `BibliocommonsEventsScraper` and 
 | **Tockify** | `https://tockify.com/api/feeds/ics/{CALENDAR_ID}` |
 | **LiveWhale** | `https://{domain}/live/ical/events` |
 | **Localist** | `https://{domain}/api/2/events` |
+| **GoDaddy Calendar** | Check DevTools for `calendar.apps.secureserver.net` requests (use scraper) |
 | **WordPress Tribe** | `https://example.com/events/?ical=1` |
 | **WordPress MEC** | `https://example.com/events/?mec-ical-feed=1` |
 | **Legistar** | `https://webapi.legistar.com/v1/{client}/events` (WebAPI, use scraper) |

--- a/scrapers/lib/godaddy.py
+++ b/scrapers/lib/godaddy.py
@@ -1,0 +1,138 @@
+"""GoDaddy Website Builder calendar scraper library.
+
+GoDaddy Website Builder sites with a calendar widget serve event data from a
+JSON API at calendar.apps.secureserver.net. The API returns structured events
+with title, description, location, start/end times, and allDay flag.
+
+API URL pattern:
+    https://calendar.apps.secureserver.net/v1/events/{website_id}/{section_id}/{widget_id}
+
+To find IDs: open the site's calendar page in a browser, check network requests
+for a GET to calendar.apps.secureserver.net.
+
+Usage:
+    from lib.godaddy import GoDaddyScraper
+
+    class MyVenueScraper(GoDaddyScraper):
+        name = "My Venue"
+        domain = "myvenue.com"
+        website_id = "850abeb2-..."
+        section_id = "9c296a07-..."
+        widget_id = "f33a9bca-..."
+        default_location = "My Venue, 123 Main St, Anytown, CA"
+
+    if __name__ == '__main__':
+        MyVenueScraper.main()
+"""
+
+import html as html_mod
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+import requests
+
+from .base import BaseScraper
+from .utils import DEFAULT_HEADERS
+
+
+API_BASE = "https://calendar.apps.secureserver.net/v1/events"
+
+
+class GoDaddyScraper(BaseScraper):
+    """Base class for scrapers targeting GoDaddy Website Builder calendar widgets.
+
+    Subclasses should set:
+        name: str - Source name
+        domain: str - Domain for UIDs
+        website_id: str - GoDaddy website UUID
+        section_id: str - Calendar section UUID
+        widget_id: str - Calendar widget UUID
+        default_location: str - Fallback location string
+    """
+
+    website_id: str = ''
+    section_id: str = ''
+    widget_id: str = ''
+    default_location: str = ''
+
+    def fetch_events(self) -> list[dict[str, Any]]:
+        """Fetch events from GoDaddy calendar API."""
+        url = f"{API_BASE}/{self.website_id}/{self.section_id}/{self.widget_id}"
+        self.logger.info(f"Fetching {url}")
+
+        try:
+            resp = requests.get(url, headers=DEFAULT_HEADERS, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+        except (requests.RequestException, ValueError) as e:
+            self.logger.error(f"Failed to fetch: {e}")
+            return []
+
+        raw_events = data.get('events', [])
+        self.logger.info(f"API returned {len(raw_events)} events")
+
+        events = []
+        for item in raw_events:
+            parsed = self._parse_event(item)
+            if parsed:
+                events.append(parsed)
+
+        self.logger.info(f"Parsed {len(events)} events")
+        return events
+
+    def _parse_event(self, item: dict) -> Optional[dict[str, Any]]:
+        """Parse a single event from the GoDaddy API response."""
+        title = item.get('title', '').strip()
+        if not title:
+            return None
+
+        start_str = item.get('start', '')
+        if not start_str:
+            return None
+
+        try:
+            dtstart = datetime.fromisoformat(start_str)
+        except (ValueError, TypeError):
+            return None
+
+        # Localize naive datetimes to the scraper's configured timezone
+        if dtstart.tzinfo is None:
+            tz = ZoneInfo(self.timezone) if isinstance(self.timezone, str) else self.timezone
+            dtstart = dtstart.replace(tzinfo=tz)
+
+        # Skip past events
+        now = datetime.now(timezone.utc)
+        if dtstart < now:
+            return None
+
+        dtend = None
+        end_str = item.get('end', '')
+        if end_str:
+            try:
+                dtend = datetime.fromisoformat(end_str)
+                if dtend.tzinfo is None:
+                    tz = ZoneInfo(self.timezone) if isinstance(self.timezone, str) else self.timezone
+                    dtend = dtend.replace(tzinfo=tz)
+            except (ValueError, TypeError):
+                pass
+
+        # Clean description: strip HTML tags, unescape entities
+        desc = item.get('desc', '') or ''
+        desc = html_mod.unescape(desc)
+        desc = re.sub(r'<[^>]+>', ' ', desc).strip()
+        desc = re.sub(r'\s+', ' ', desc)
+        # Truncate very long descriptions (some GoDaddy calendar entries can be huge)
+        if len(desc) > 500:
+            desc = desc[:497] + '...'
+
+        location = item.get('location', '').strip() or self.default_location
+
+        return {
+            'title': title,
+            'dtstart': dtstart,
+            'dtend': dtend,
+            'location': location,
+            'description': desc,
+        }


### PR DESCRIPTION
## Summary
- New reusable scraper library: `scrapers/lib/godaddy.py`
- Targets GoDaddy Website Builder sites with calendar/events widgets
- Uses the structured JSON API at `calendar.apps.secureserver.net` — no headless browser needed
- Documents the scraper in AGENTS.md (Reusable Scrapers section + Platform-Specific Techniques table)

## How it works
GoDaddy Website Builder calendar widgets fetch event data from a JSON API:
```
https://calendar.apps.secureserver.net/v1/events/{website_id}/{section_id}/{widget_id}
```

The three UUIDs can be found by opening the site's calendar page in DevTools and watching network requests. The API returns clean JSON with titles, descriptions, locations, and start/end times.

## Usage
Subclass `GoDaddyScraper` with the three IDs:
```python
from lib.godaddy import GoDaddyScraper

class MyVenueScraper(GoDaddyScraper):
    name = "My Venue"
    domain = "myvenue.com"
    website_id = "850abeb2-..."
    section_id = "9c296a07-..."
    widget_id = "f33a9bca-..."
    default_location = "My Venue, 123 Main St, Anytown, CA"
    timezone = "America/Los_Angeles"

if __name__ == '__main__':
    MyVenueScraper.main()
```

## Test plan
- [x] Tested against a live GoDaddy site (wellness studio with ~100 recurring events)
- [x] Handles HTML descriptions (strips tags, unescapes entities, truncates)
- [x] Timezone-aware: localizes naive datetimes from API to configured timezone
- [x] Follows existing library patterns (matches `squarespace.py`, `elfsight.py` structure)


🤖 Generated with [Claude Code](https://claude.com/claude-code)