### PR TITLE
feat(bloomington): add Harmony School calendar feed

### DIFF
--- a/cities/bloomington/feeds.txt
+++ b/cities/bloomington/feeds.txt
@@ -185,3 +185,6 @@ cities/bloomington/tm_bill_armstrong.ics
 cities/bloomington/tm_wells_metz.ics
 # cmd: python scrapers/ticketmaster.py --venue-id KovZpZAFdItA --name "Simon Skjodt Assembly Hall"
 cities/bloomington/tm_assembly_hall.ics
+
+# Harmony School Calendar
+https://calendar.google.com/calendar/ical/c_eec83e1cbfbdf8804b061fbaa23ea7300a127c74c0668e9512747006f10b3833@group.calendar.google.com/public/basic.ics


### PR DESCRIPTION
Add Google Calendar ICS feed for Harmony School to Bloomington's feeds.txt. This provides access to school events and activities for the community calendar.