### PR TITLE
Asheville: Split ACS into per-school feeds; adding SILSA and Preschool 

### DIFF
--- a/cities/asheville/SOURCES_CHECKLIST.md
+++ b/cities/asheville/SOURCES_CHECKLIST.md
@@ -18,7 +18,18 @@
 | Buncombe County Parks & Recreation | CivicPlus ICS (catID=40) | 51 | `buncombenc.gov/…?catID=40&feed=calendar` |
 | Buncombe County Public Health Mobile Team | CivicPlus ICS (catID=35) | 39 | `buncombenc.gov/…?catID=35&feed=calendar`; added manually (add_feed.py test fails on cp1252 decode of feed content) |
 | Buncombe County Planning | CivicPlus ICS (catID=37) | 23 | `buncombenc.gov/…?catID=37&feed=calendar` |
-| Asheville City Schools | Finalsite `fs/calendar-manager` combined feed (district + 9 schools + CTE, IDs 18,17,20,15,14,21,27,22,26,23,24,25,28,29,34,10) | 1275 | `ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids[]=...`; 75 upcoming as of 2026-07-10 — low mid-summer count expected, populates for fall term. See AGENTS.md Platform-Specific Techniques for the Finalsite URL pattern. |
+| Asheville City Schools | Finalsite ICS (IDs 26,27,14,15,17,18) | 220 | `ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids[]=...` — district + enrollment calendars. See AGENTS.md Platform-Specific Techniques for the Finalsite URL pattern. |
+| Asheville High School | Finalsite ICS (ID 25) | 140 | `ashevillecityschools.net/…?calendar_ids[]=25` |
+| SILSA | Finalsite ICS (ID 32) | 13 | `ashevillecityschools.net/…?calendar_ids[]=32` |
+| Asheville Middle School | Finalsite ICS (IDs 24,10,6) | 602 | `ashevillecityschools.net/…?calendar_ids[]=24…` |
+| Claxton Elementary School | Finalsite ICS (ID 23) | 74 | `ashevillecityschools.net/…?calendar_ids[]=23` |
+| Hall Fletcher Elementary | Finalsite ICS (ID 21) | 30 | `ashevillecityschools.net/…?calendar_ids[]=21` |
+| Isaac Dickson Elementary | Finalsite ICS (IDs 28,2) | 112 | `ashevillecityschools.net/…?calendar_ids[]=28…` |
+| Ira B. Jones Elementary | Finalsite ICS (ID 29) | 0 | `ashevillecityschools.net/…?calendar_ids[]=29` — empty mid-summer, populates for fall term |
+| Lucy S. Herring Elementary | Finalsite ICS (ID 20) | 0 | `ashevillecityschools.net/…?calendar_ids[]=20` — empty mid-summer, populates for fall term |
+| ECA at William Randolph | Finalsite ICS (ID 22) | 7 | `ashevillecityschools.net/…?calendar_ids[]=22` |
+| ACS Career and Technical Education | Finalsite ICS (ID 34) | 91 | `ashevillecityschools.net/…?calendar_ids[]=34` |
+| ACS Preschool Program | Finalsite ICS (ID 30) | 2 | `ashevillecityschools.net/…?calendar_ids[]=30` |
 
 ### Songkick Scrapers
 

--- a/cities/asheville/pending_feeds.txt
+++ b/cities/asheville/pending_feeds.txt
@@ -35,3 +35,39 @@
 #   python scripts/add_scraper.py example asheville "Source Name" --test
 #
 # See CONTRIBUTING.md for details.
+
+# Asheville City Schools
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=26&calendar_ids%5B%5D=27&calendar_ids%5B%5D=14&calendar_ids%5B%5D=15&calendar_ids%5B%5D=17&calendar_ids%5B%5D=18
+
+# Asheville High School
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=25
+
+# SILSA
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=32
+
+# Asheville Middle School
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=24&calendar_ids%5B%5D=10&calendar_ids%5B%5D=6
+
+# Claxton Elementary School
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=23
+
+# Hall Fletcher Elementary
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=21
+
+# Isaac Dickson Elementary
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=28&calendar_ids%5B%5D=2
+
+# Ira B. Jones Elementary
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=29
+
+# Lucy S. Herring Elementary
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=20
+
+# ECA at William Randolph
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=22
+
+# ACS Career and Technical Education
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=34
+
+# ACS Preschool Program
+https://www.ashevillecityschools.net/fs/calendar-manager/events.ics?calendar_ids%5B%5D=30


### PR DESCRIPTION
Pull request #71 added Asheville City Schools but event display names were all stamped with the same name. The names will now reflect the appropriate school. Claude states that a manual step remains (I don't know how true this is).

- Delete the old combined feed. Someone with admin access on the production app must open the Manage Feeds dialog and delete the old "Asheville City Schools" feed (the one whose URL lists all 16 calendar_ids; careful not to delete the new district feed, which has the same name but a URL with only IDs 26,27,14,15,17,18). That deletes its events and its feeds row. Until this happens, old and new feeds coexist: the same school events get dedup-merged and the source line shows both names, e.g. "Asheville City Schools, Claxton Elementary School". This is judell's call.