### PR TITLE
Fix stale-paint suppression in issue-82 emission coalescing

### DIFF
--- a/scripts/bench_collapse_long.js
+++ b/scripts/bench_collapse_long.js
@@ -145,7 +145,17 @@ function main() {
     console.error('ERROR: fresh reference array not actually fresh — test is broken');
     process.exit(2);
   }
+  // Snapshot both cache layers before run #2. The hit may land in either: the
+  // content-key cache (logs "cache HIT" via _pipelineLog) or the issue-82
+  // memoize wrapper (short-circuits before it and bumps
+  // __ccMemoStats.collapseLongRunningEvents.hits instead, with no log).
+  const memoStats = windowObj.__ccMemoStats && windowObj.__ccMemoStats.collapseLongRunningEvents;
+  const memoHitsBefore = memoStats ? memoStats.hits : 0;
+  const logLenBefore = windowObj._pipelineLog.length;
   const run2 = run(freshRefs, 'run#2 (network emit, fresh refs)');
+  const run2Hit =
+    /cache HIT/.test(windowObj._pipelineLog.slice(logLenBefore).join('\n')) ||
+    (memoStats && memoStats.hits > memoHitsBefore);
   console.log('run#2: ' + run2.ms.toFixed(1) + 'ms');
 
   // Run #3 — repeat to confirm the cache stays warm.
@@ -155,15 +165,17 @@ function main() {
   console.log('');
   console.log('window._pipelineLog:');
   windowObj._pipelineLog.forEach(function (line) { console.log('  ' + line); });
+  if (memoStats) {
+    console.log('window.__ccMemoStats.collapseLongRunningEvents: ' + memoStats.hits + ' hits / ' + memoStats.misses + ' misses');
+  }
   console.log('');
 
   // --- Assertions -----------------------------------------------------------
   const failures = [];
   const HIT_THRESHOLD_MS = 5; // cache hits take microseconds; 5ms is generous
 
-  const run2Hit = /cache HIT/.test(windowObj._pipelineLog[windowObj._pipelineLog.length - 2] || '');
   if (!run2Hit) {
-    failures.push('run#2 was not a cache HIT (expected content-key cache hit on fresh references)');
+    failures.push('run#2 was not a cache HIT at either layer (content-key cache or issue-82 memoize)');
   }
   if (run2.ms > HIT_THRESHOLD_MS) {
     failures.push('run#2 took ' + run2.ms.toFixed(1) + 'ms (expected < ' + HIT_THRESHOLD_MS + 'ms; regression was 254-336ms)');

--- a/xmlui/helpers.js
+++ b/xmlui/helpers.js
@@ -247,35 +247,52 @@ function getEventSearchText(event) {
 // Strong content identity for an events payload. shell.js's issue-82
 // emission coalescing uses this to decide whether a fresh fetch is
 // identical to the paint it would replace. Unlike ccArraySig — kept O(1)
-// because memoizeIngest runs it on every evaluation — this is called at
-// most twice per load (once per cache paint, once per fetch), so it can
-// afford to hash every row. The previous key (length + first/last id)
-// called two payloads identical when only the middle changed, which let a
-// stale cached paint suppress the fresh emission and, after the epoch
-// nudge landed, leave the repaint unfired. Two independent 32-bit FNV-1a
-// hashes keep an accidental collision between distinct payloads
-// negligible; the length prefix is part of the returned key.
+// because memoizeIngest runs it on every evaluation — this runs only a
+// handful of times per load (cache paint, fetch compare/store, refetch),
+// so it can afford to examine every row. The previous key (length +
+// first/last id) called two payloads identical when only the middle
+// changed, which let a stale cached paint suppress the fresh emission
+// and, after the epoch nudge landed, leave the repaint unfired. Two
+// 32-bit multiplicative hashes with independent seeds (an FNV-1a pass and
+// a MurmurHash3-style pass) over the same stream give ~64 bits, so an
+// accidental collision between distinct payloads is negligible.
 function eventsSignature(rows) {
   if (!Array.isArray(rows)) return 'na';
   if (!rows.length) return '0';
-  var h1 = 0x811c9dc5;
-  var h2 = 0x811c9dc5;
+  var h1 = 0x811c9dc5; // FNV-1a offset basis
+  var h2 = 0x9747b28c; // independent seed
   for (var i = 0; i < rows.length; i++) {
     var row = rows[i];
     var s = row === undefined ? 'undefined' : JSON.stringify(row);
     if (s === undefined) s = 'undefined';
     for (var j = 0; j < s.length; j++) {
       var c = s.charCodeAt(j);
-      h1 = Math.imul(h1 ^ c, 16777619);
-      h2 = Math.imul(h2 ^ c, 2246822519);
+      h1 = Math.imul(h1 ^ c, 0x01000193); // FNV-1a prime
+      h2 = Math.imul(h2 ^ c, 0x85ebca6b); // MurmurHash3 constant
     }
     // Row separator: keeps ["ab"] from hashing the same as ["a", "b"].
-    h1 = Math.imul(h1 ^ 0x1f, 16777619);
-    h2 = Math.imul(h2 ^ 0x1f, 2246822519);
+    h1 = Math.imul(h1 ^ 0x1f, 0x01000193);
+    h2 = Math.imul(h2 ^ 0x1f, 0x85ebca6b);
   }
   return rows.length + ':' + (h1 >>> 0).toString(16) + ':' + (h2 >>> 0).toString(16);
 }
 window.eventsSignature = eventsSignature;
+
+// The issue-82 fresh-emission skip decision, extracted from shell.js so
+// test.html can pin the coalescing itself, not just the signature: a fresh
+// payload is skipped only when it is identical to the last emission and
+// came from the same subscriber and city. With the old weak key, a
+// mid-payload change looked identical and suppressed the fresh emit — and
+// therefore the epoch bump that repaints the stale cache.
+function shouldSkipFreshEmit(state, rows) {
+  return !!(
+    state.currentEmit &&
+    state.currentEmit === state.lastEmitFn &&
+    state.city === state.lastEmitCity &&
+    eventsSignature(rows) === state.lastEmitSig
+  );
+}
+window.shouldSkipFreshEmit = shouldSkipFreshEmit;
 
 // Filter events by search term with progressive narrowing
 var _prevTerm = '';

--- a/xmlui/helpers.js
+++ b/xmlui/helpers.js
@@ -244,6 +244,39 @@ function getEventSearchText(event) {
   ).toLowerCase();
 }
 
+// Strong content identity for an events payload. shell.js's issue-82
+// emission coalescing uses this to decide whether a fresh fetch is
+// identical to the paint it would replace. Unlike ccArraySig — kept O(1)
+// because memoizeIngest runs it on every evaluation — this is called at
+// most twice per load (once per cache paint, once per fetch), so it can
+// afford to hash every row. The previous key (length + first/last id)
+// called two payloads identical when only the middle changed, which let a
+// stale cached paint suppress the fresh emission and, after the epoch
+// nudge landed, leave the repaint unfired. Two independent 32-bit FNV-1a
+// hashes keep an accidental collision between distinct payloads
+// negligible; the length prefix is part of the returned key.
+function eventsSignature(rows) {
+  if (!Array.isArray(rows)) return 'na';
+  if (!rows.length) return '0';
+  var h1 = 0x811c9dc5;
+  var h2 = 0x811c9dc5;
+  for (var i = 0; i < rows.length; i++) {
+    var row = rows[i];
+    var s = row === undefined ? 'undefined' : JSON.stringify(row);
+    if (s === undefined) s = 'undefined';
+    for (var j = 0; j < s.length; j++) {
+      var c = s.charCodeAt(j);
+      h1 = Math.imul(h1 ^ c, 16777619);
+      h2 = Math.imul(h2 ^ c, 2246822519);
+    }
+    // Row separator: keeps ["ab"] from hashing the same as ["a", "b"].
+    h1 = Math.imul(h1 ^ 0x1f, 16777619);
+    h2 = Math.imul(h2 ^ 0x1f, 2246822519);
+  }
+  return rows.length + ':' + (h1 >>> 0).toString(16) + ':' + (h2 >>> 0).toString(16);
+}
+window.eventsSignature = eventsSignature;
+
 // Filter events by search term with progressive narrowing
 var _prevTerm = '';
 var _prevCategory = '';
@@ -1648,8 +1681,9 @@ if (typeof window !== 'undefined') {
   // stable, yet ref-keyed memos still missed at engine-mediated stage
   // boundaries — the engine gives intermediate expression results fresh
   // identities per evaluation. Signatures sidestep identity entirely.
-  // (Known tradeoff, same as shell.js rowsSig: a mid-array content change
-  // with identical length and endpoint ids would falsely hit.)
+  // (Known ccArraySig tradeoff: a mid-array content change with identical
+  // length and endpoint ids would falsely hit. The emission coalescing in
+  // shell.js keys on eventsSignature, a full-payload hash, instead.)
   window.__ccMemoStats = {};
   function memoizeIngest(name, extraKey) {
     var orig = window[name];
@@ -1692,9 +1726,9 @@ if (typeof window !== 'undefined') {
   // full-price chain runs even after ref memoization, i.e. the engine
   // presents a different events.value/enrichments.value identity per
   // binding evaluation. So the boundary memo keys on a cheap content
-  // signature instead (length + first/last ids — the same identity test
-  // shell.js uses to skip identical emissions), and __ccRefStats counts
-  // the identity churn as evidence for the upstream XMLUI finding.
+  // signature instead (the ccArraySig length + first/last id test), and
+  // __ccRefStats counts the identity churn as evidence for the upstream
+  // XMLUI finding.
   function ccArraySig(a) {
     if (!Array.isArray(a)) return 'na';
     if (!a.length) return '0';

--- a/xmlui/shell.js
+++ b/xmlui/shell.js
@@ -506,8 +506,13 @@ window._xsLogs = [];
         if (city !== window.cityFilter) return false;  // stale-city race guard (#76)
         // issue-82: skip the replacement when this same subscriber already
         // holds identical data — the emit would only trigger a re-render.
-        if (currentEmit && currentEmit === lastEmitFn &&
-            city === lastEmitCity && window.eventsSignature(rows) === lastEmitSig) {
+        if (window.shouldSkipFreshEmit({
+              currentEmit: currentEmit,
+              lastEmitFn: lastEmitFn,
+              city: city,
+              lastEmitCity: lastEmitCity,
+              lastEmitSig: lastEmitSig,
+            }, rows)) {
           performance.mark('cc-events-skip-fresh-identical');
           return true;
         }

--- a/xmlui/shell.js
+++ b/xmlui/shell.js
@@ -467,11 +467,6 @@ window._xsLogs = [];
     var lastEmitCity = null;
     var lastEmitSig = null;
 
-    function rowsSig(rows) {
-      return rows.length + ':' +
-        (rows.length ? rows[0].id + ':' + rows[rows.length - 1].id : '');
-    }
-
     function eventsUrl(city) {
       return window.SUPABASE_URL + '/rest/v1/deduplicated_events' +
         '?select=id,title,start_time,end_time,url,location,description,source,transcript,cluster_id,source_urls,category,image_url,all_day,merged_ids,city' +
@@ -512,7 +507,7 @@ window._xsLogs = [];
         // issue-82: skip the replacement when this same subscriber already
         // holds identical data — the emit would only trigger a re-render.
         if (currentEmit && currentEmit === lastEmitFn &&
-            city === lastEmitCity && rowsSig(rows) === lastEmitSig) {
+            city === lastEmitCity && window.eventsSignature(rows) === lastEmitSig) {
           performance.mark('cc-events-skip-fresh-identical');
           return true;
         }
@@ -520,7 +515,7 @@ window._xsLogs = [];
         if (currentEmit) {
           lastEmitFn = currentEmit;
           lastEmitCity = city;
-          lastEmitSig = rowsSig(rows);
+          lastEmitSig = window.eventsSignature(rows);
           currentEmit(rows);
         }
         return true;
@@ -557,7 +552,7 @@ window._xsLogs = [];
           performance.mark('cc-events-emit-cached');
           lastEmitFn = emit;
           lastEmitCity = city;
-          lastEmitSig = rowsSig(cached);
+          lastEmitSig = window.eventsSignature(cached);
           emit(cached);
         }
       });

--- a/xmlui/test.html
+++ b/xmlui/test.html
@@ -1184,6 +1184,58 @@
       }
 
       // ============================================================
+      // eventsSignature — issue-82 coalescing identity
+      // ============================================================
+      // shell.js skips a fresh emission only when it is truly identical to
+      // what was already emitted. The old key (length + first/last id)
+      // treated a mid-array content change as identical, so a stale cached
+      // paint could suppress the fresh emit and, after the epoch nudge,
+      // leave the repaint unfired. These lock the stronger contract.
+      describe('eventsSignature', () => {
+        const stale = [
+          { id: 1, title: 'Early', start_time: '2026-01-01T10:00:00Z' },
+          { id: 2, title: 'Middle OLD', start_time: '2026-01-02T10:00:00Z' },
+          { id: 3, title: 'Late', start_time: '2026-01-03T10:00:00Z' }
+        ];
+        const fresh = [
+          { id: 1, title: 'Early', start_time: '2026-01-01T10:00:00Z' },
+          { id: 2, title: 'Middle NEW', start_time: '2026-01-02T10:00:00Z' },
+          { id: 3, title: 'Late', start_time: '2026-01-03T10:00:00Z' }
+        ];
+
+        it('is exported', () => {
+          assertEqual(typeof eventsSignature, 'function');
+        });
+
+        it('distinguishes payloads that differ only between the endpoint ids', () => {
+          assert(eventsSignature(stale) !== eventsSignature(fresh),
+            'a mid-array content change must change the signature');
+        });
+
+        it('is stable for identical content across distinct references', () => {
+          assertEqual(eventsSignature(stale), eventsSignature(JSON.parse(JSON.stringify(stale))));
+        });
+
+        it('catches an in-place field edit with identical ids', () => {
+          const edited = JSON.parse(JSON.stringify(stale));
+          edited[1].start_time = '2026-01-02T11:00:00Z';
+          assert(eventsSignature(stale) !== eventsSignature(edited),
+            'a field edit must change the signature');
+        });
+
+        it('returns a stable key for empty and non-array input', () => {
+          assertEqual(eventsSignature([]), eventsSignature([]));
+          assertEqual(eventsSignature(null), eventsSignature(null));
+          assertEqual(eventsSignature(undefined), eventsSignature(undefined));
+        });
+
+        it('treats a reordering as a change', () => {
+          assert(eventsSignature(stale) !== eventsSignature([stale[1], stale[0], stale[2]]),
+            'order must be part of the identity');
+        });
+      });
+
+      // ============================================================
       // RENDER RESULTS
       // ============================================================
 

--- a/xmlui/test.html
+++ b/xmlui/test.html
@@ -1224,14 +1224,59 @@
         });
 
         it('returns a stable key for empty and non-array input', () => {
-          assertEqual(eventsSignature([]), eventsSignature([]));
-          assertEqual(eventsSignature(null), eventsSignature(null));
-          assertEqual(eventsSignature(undefined), eventsSignature(undefined));
+          assertEqual(eventsSignature([]), '0');
+          assertEqual(eventsSignature(null), 'na');
+          assertEqual(eventsSignature(undefined), 'na');
         });
 
         it('treats a reordering as a change', () => {
           assert(eventsSignature(stale) !== eventsSignature([stale[1], stale[0], stale[2]]),
             'order must be part of the identity');
+        });
+      });
+
+      // ============================================================
+      // shouldSkipFreshEmit — the coalescing decision shell.js makes
+      // ============================================================
+      // Pins the coalescing itself, not just the signature: with the old
+      // weak key, a fresh payload that differed only in the middle matched
+      // the cached paint's signature and was skipped, so eventsEpoch never
+      // bumped and the stale paint stayed on screen.
+      describe('shouldSkipFreshEmit', () => {
+        const emit = function () {};
+        const state = (lastSig) => ({
+          currentEmit: emit,
+          lastEmitFn: emit,
+          city: 'davis',
+          lastEmitCity: 'davis',
+          lastEmitSig: lastSig
+        });
+        const stale = [
+          { id: 1, title: 'Early' },
+          { id: 2, title: 'Middle OLD' },
+          { id: 3, title: 'Late' }
+        ];
+        const fresh = [
+          { id: 1, title: 'Early' },
+          { id: 2, title: 'Middle NEW' },
+          { id: 3, title: 'Late' }
+        ];
+
+        it('does not skip a fresh payload that differs only in the middle', () => {
+          assertEqual(shouldSkipFreshEmit(state(eventsSignature(stale)), fresh), false);
+        });
+
+        it('skips a truly identical payload for the same subscriber and city', () => {
+          const copy = JSON.parse(JSON.stringify(stale));
+          assertEqual(shouldSkipFreshEmit(state(eventsSignature(stale)), copy), true);
+        });
+
+        it('does not skip when no subscriber is current', () => {
+          assertEqual(shouldSkipFreshEmit({ ...state(eventsSignature(stale)), currentEmit: null }, stale), false);
+        });
+
+        it('does not skip for a different city', () => {
+          assertEqual(shouldSkipFreshEmit({ ...state(eventsSignature(stale)), city: 'davis', lastEmitCity: 'santarosa' }, stale), false);
         });
       });
 


### PR DESCRIPTION
## Problem

The issue-82 emission coalescing decides whether a fresh fetch is identical to the paint it would replace using `rowsSig` — `length + first/last id`:

```js
function rowsSig(rows) {
  return rows.length + ':' + (rows.length ? rows[0].id + ':' + rows[rows.length - 1].id : '');
}
```

That key misses a change confined to the middle of the payload. A stale cached paint and the fresh fetch can share a length and both endpoint ids while differing in between, so `deliverFresh` takes the `cc-events-skip-fresh-identical` branch and never emits the fresh rows.

Since the epoch nudge landed (`7a1205556`), that skipped emit is also the only thing that bumps `eventsEpoch`, so the stale paint never repaints — the exact failure mode the epoch nudge was added to prevent.

## Fix

Add `window.eventsSignature(rows)` in `helpers.js` — a full-payload content hash (two independent 32-bit FNV-1a passes, length-prefixed) — and key the coalescing on it. It runs at most twice per load (once per cache paint, once per fetch), so unlike the O(1) `ccArraySig` memo key it can afford to examine every row.

The `ccArraySig` memo keys are intentionally left alone: they run on every pipeline evaluation and must stay O(1). Their documented tradeoff is unchanged; the two comments that referenced "the same identity test shell.js uses" are updated to point at the new key.

## Tests

`xmlui/test.html` gains two groups (10 tests):

**`eventsSignature` (6)** — the load-bearing one fails against the old key and passes against the new one:

- distinguishes payloads that differ only between the endpoint ids
- stable for identical content across distinct references
- catches an in-place field edit with identical ids
- returns the `'0'` / `'na'` sentinels for empty and non-array input
- treats reordering as a change

**`shouldSkipFreshEmit` (4)** — `test.html` loads `helpers.js` only, so testing the signature in isolation left the `shell.js` coalescing site unpinned: a regression that rewired `deliverFresh` back to the weak key would have stayed green. The decision is now a pure `shouldSkipFreshEmit(state, rows)` that `deliverFresh` calls, pinned directly:

- does not skip a fresh payload that differs only in the middle
- skips a truly identical payload for the same subscriber and city
- does not skip when no subscriber is current
- does not skip for a different city

Run by opening `xmlui/test.html`; both groups pass. Four pre-existing failures remain in other groups in this environment (rrule/CDN-dependent tests and the real-data fetch, which needs `config.local.js`); they are present on `main` and unrelated to this change.

## Also fixes the `perf-gate` job

`perf-gate` was already red on `upstream/main` before this PR. The adopted `scripts/bench_collapse_long.js` only read `_pipelineLog[length - 2]`, the inner content-key cache's log line. The issue-82 memoize wrapper short-circuits run #2 before that inner function runs, so it logs nothing and records the hit as `__ccMemoStats.collapseLongRunningEvents.hits` instead — the assertion could never pass. The job runs only on `pull_request`, so it went unnoticed until this PR touched `xmlui/helpers.js`.

This PR snapshots both cache layers around run #2 and accepts a hit at either, matching the B-Square fork's current bench from which the upstream copy was adopted. Verified: the fixed bench passes on pristine `upstream/main` and on this branch, and fails when both cache layers are disabled. The timing and result-equality assertions are unchanged, so a real recompute still fails the gate.

## Files

- `xmlui/helpers.js` — new `eventsSignature` + `shouldSkipFreshEmit`, comment updates
- `xmlui/shell.js` — `deliverFresh` calls `shouldSkipFreshEmit`; local `rowsSig` removed
- `xmlui/test.html` — `eventsSignature` and `shouldSkipFreshEmit` groups
- `scripts/bench_collapse_long.js` — check both cache layers (pre-existing gate fix)
